### PR TITLE
fix: avoid setup language switcher overlap

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -393,6 +393,14 @@
     @apply w-full max-w-3xl;
   }
 
+  .setup-language-switcher {
+    @apply mb-4 flex w-full max-w-3xl justify-end;
+  }
+
+  .setup-language-switcher-control {
+    @apply inline-flex items-center gap-1 rounded-full border border-border/70 bg-background/80 px-1 py-1 text-muted-foreground shadow-sm backdrop-blur-sm;
+  }
+
   .setup-stage {
     @apply grid gap-5;
   }

--- a/packages/web/src/modules/setup/SetupWizard.tsx
+++ b/packages/web/src/modules/setup/SetupWizard.tsx
@@ -407,18 +407,19 @@ export default function SetupWizard({ onComplete }: SetupWizardProps) {
 
   return (
     <div className="fullscreen-shell px-6">
-      {/* Language Switcher */}
-      <div className="absolute top-4 right-4 flex items-center gap-1 text-muted-foreground">
-        <Globe className="w-4 h-4" />
-        <select
-          value={i18n.language}
-          onChange={(e) => changeLanguage(e.target.value)}
-          className="text-xs bg-transparent border border-border rounded px-1.5 py-1 cursor-pointer hover:text-foreground"
-        >
-          <option value="zh">中文</option>
-          <option value="en">English</option>
-          <option value="ja">日本語</option>
-        </select>
+      <div className="setup-language-switcher">
+        <div className="setup-language-switcher-control">
+          <Globe className="w-4 h-4" />
+          <select
+            value={i18n.language}
+            onChange={(e) => changeLanguage(e.target.value)}
+            className="text-xs bg-transparent border border-border rounded px-1.5 py-1 cursor-pointer hover:text-foreground"
+          >
+            <option value="zh">中文</option>
+            <option value="en">English</option>
+            <option value="ja">日本語</option>
+          </select>
+        </div>
       </div>
 
       {isCapabilityPhase ? (


### PR DESCRIPTION
## Summary
- move the setup wizard language switcher back into normal layout flow
- add a lightweight container style so the control no longer sits on top of the hero card border
- keep the existing language options and interaction unchanged

## Testing
- npm run test --workspace=@openclaw-manager/web -- SetupWizard
- npm run build --workspace=@openclaw-manager/web