### PR TITLE
fix: resolve clawprobe via npm global prefix in web backend

### DIFF
--- a/packages/backend/src/execClawprobe.ts
+++ b/packages/backend/src/execClawprobe.ts
@@ -1,10 +1,12 @@
-import { execFile } from 'node:child_process'
+import { execFile, execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import path from 'node:path'
 import { promisify } from 'node:util'
 
 const require = createRequire(import.meta.url)
 const execFileAsync = promisify(execFile)
+let cachedClawprobeCommand: { cmd: string; argsPrefix: string[] } | undefined
 
 export class ClawprobeUnavailableError extends Error {
   code = 'CLAWPROBE_UNAVAILABLE'
@@ -22,24 +24,61 @@ export interface ClawprobeCommandOutput {
   stderr: string
 }
 
-function resolveClawprobeEntry(): string {
+function resolveLocalClawprobeEntry(): string | null {
   try {
     const pkgJson = require.resolve('clawprobe/package.json')
     const root = path.dirname(pkgJson)
     return path.join(root, 'dist', 'index.js')
   } catch {
-    // Fallback: clawprobe installed globally — use the binary directly
-    return 'clawprobe'
+    return null
   }
 }
 
 function resolveClawprobeCommand() {
-  const entry = resolveClawprobeEntry()
-  const isGlobalBin = !entry.endsWith('.js')
-  return {
-    cmd: isGlobalBin ? entry : process.execPath,
-    argsPrefix: isGlobalBin ? [] : [entry],
+  if (cachedClawprobeCommand) {
+    return cachedClawprobeCommand
   }
+
+  const localEntry = resolveLocalClawprobeEntry()
+  if (localEntry) {
+    cachedClawprobeCommand = {
+      cmd: process.execPath,
+      argsPrefix: [localEntry],
+    }
+    return cachedClawprobeCommand
+  }
+
+  try {
+    const prefix = execFileSync('npm', ['config', 'get', 'prefix'], {
+      encoding: 'utf8',
+      env: process.env,
+    }).trim()
+    if (prefix) {
+      const globalBin =
+        process.platform === 'win32'
+          ? path.join(prefix, 'clawprobe.cmd')
+          : path.join(prefix, 'bin', 'clawprobe')
+      if (existsSync(globalBin)) {
+        cachedClawprobeCommand = {
+          cmd: globalBin,
+          argsPrefix: [],
+        }
+        return cachedClawprobeCommand
+      }
+    }
+  } catch {
+    // Fall through to PATH-based resolution.
+  }
+
+  cachedClawprobeCommand = {
+    cmd: 'clawprobe',
+    argsPrefix: [],
+  }
+  return cachedClawprobeCommand
+}
+
+export function resetClawprobeCommandCacheForTests(): void {
+  cachedClawprobeCommand = undefined
 }
 
 function isClawprobeUnavailableFailure(

--- a/packages/backend/src/routes/execRoutes.ts
+++ b/packages/backend/src/routes/execRoutes.ts
@@ -4,6 +4,7 @@ import { promisify } from 'util'
 import { existsSync } from 'fs'
 import { homedir, tmpdir, platform } from 'os'
 import path from 'path'
+import { runClawprobeCommand } from '../execClawprobe.js'
 import { execOpenclaw } from '../execOpenclaw.js'
 
 const execFileAsync = promisify(execFile)
@@ -108,6 +109,17 @@ export function registerExecRoutes(app: Express): void {
           stderr: result.stderr.trim(),
           exitCode: result.code,
           ...(result.code === 0 ? {} : { error: result.stderr.trim() || result.stdout.trim() }),
+        })
+        return
+      }
+      if (normalized.cmd === 'clawprobe') {
+        const result = await runClawprobeCommand(normalized.args)
+        res.json({
+          ok: result.ok,
+          stdout: result.stdout.trim(),
+          stderr: result.stderr.trim(),
+          exitCode: result.code,
+          ...(result.ok ? {} : { error: result.stderr.trim() || result.stdout.trim() || 'clawprobe failed' }),
         })
         return
       }

--- a/packages/backend/src/services/clawprobeResolution.test.ts
+++ b/packages/backend/src/services/clawprobeResolution.test.ts
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import express from 'express'
+
+import { resetClawprobeCommandCacheForTests } from '../execClawprobe.js'
+import { registerExecRoutes } from '../routes/execRoutes.js'
+import { clawprobeBootstrap } from './clawprobeService.js'
+
+const originalPath = process.env.PATH
+
+function makeTempDir(label: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `clawmaster-${label}-`))
+}
+
+function writeExecutable(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, content, 'utf8')
+  fs.chmodSync(filePath, 0o755)
+}
+
+function createFakeNpm(filePath: string, prefixDir: string): void {
+  writeExecutable(
+    filePath,
+    `#!/bin/sh
+if [ "$1" = "config" ] && [ "$2" = "get" ] && [ "$3" = "prefix" ]; then
+  printf '%s\\n' "${prefixDir}"
+  exit 0
+fi
+printf 'unexpected npm args: %s\\n' "$*" >&2
+exit 1
+`
+  )
+}
+
+function createVersionOnlyClawprobe(filePath: string, version: string): void {
+  writeExecutable(
+    filePath,
+    `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  printf '%s\\n' "${version}"
+  exit 0
+fi
+printf 'unexpected clawprobe args: %s\\n' "$*" >&2
+exit 1
+`
+  )
+}
+
+function createBootstrapClawprobe(filePath: string, stateFile: string): void {
+  writeExecutable(
+    filePath,
+    `#!/bin/sh
+if [ "$1" = "status" ] && [ "$2" = "--json" ]; then
+  if [ -f "${stateFile}" ]; then
+    printf '{"ok":true,"daemonRunning":true}\\n'
+  else
+    printf '{"ok":true,"daemonRunning":false}\\n'
+  fi
+  exit 0
+fi
+if [ "$1" = "start" ]; then
+  printf 'running\\n' > "${stateFile}"
+  printf 'started\\n'
+  exit 0
+fi
+printf 'unexpected clawprobe args: %s\\n' "$*" >&2
+exit 1
+`
+  )
+}
+
+function setFakePath(binDir: string): void {
+  process.env.PATH = binDir
+}
+
+test.beforeEach(() => {
+  resetClawprobeCommandCacheForTests()
+})
+
+test.afterEach(() => {
+  resetClawprobeCommandCacheForTests()
+  if (originalPath === undefined) {
+    delete process.env.PATH
+  } else {
+    process.env.PATH = originalPath
+  }
+})
+
+test(
+  'POST /api/exec resolves clawprobe from npm global prefix when it is missing from PATH',
+  { skip: process.platform === 'win32' },
+  async () => {
+    const tempDir = makeTempDir('clawprobe-exec-route')
+    const fakePathDir = path.join(tempDir, 'path-bin')
+    const npmPrefixDir = path.join(tempDir, 'npm-prefix')
+    const globalBinDir = path.join(npmPrefixDir, 'bin')
+
+    createFakeNpm(path.join(fakePathDir, 'npm'), npmPrefixDir)
+    createVersionOnlyClawprobe(path.join(globalBinDir, 'clawprobe'), '1.3.0')
+    setFakePath(fakePathDir)
+
+    const app = express()
+    app.use(express.json())
+    registerExecRoutes(app)
+
+    const server = app.listen(0, '127.0.0.1')
+    await new Promise<void>((resolve, reject) => {
+      server.once('listening', () => resolve())
+      server.once('error', reject)
+    })
+
+    try {
+      const address = server.address()
+      assert.ok(address && typeof address !== 'string')
+
+      const response = await fetch(`http://127.0.0.1:${address.port}/api/exec`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ cmd: 'clawprobe', args: ['--version'] }),
+      })
+
+      assert.equal(response.status, 200)
+      assert.deepEqual(await response.json(), {
+        ok: true,
+        stdout: '1.3.0',
+        stderr: '',
+        exitCode: 0,
+      })
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) reject(error)
+          else resolve()
+        })
+      })
+    }
+  }
+)
+
+test(
+  'clawprobeBootstrap succeeds when clawprobe is only discoverable via npm global prefix',
+  { skip: process.platform === 'win32' },
+  async () => {
+    const tempDir = makeTempDir('clawprobe-bootstrap')
+    const fakePathDir = path.join(tempDir, 'path-bin')
+    const npmPrefixDir = path.join(tempDir, 'npm-prefix')
+    const globalBinDir = path.join(npmPrefixDir, 'bin')
+    const stateFile = path.join(tempDir, 'clawprobe.state')
+
+    createFakeNpm(path.join(fakePathDir, 'npm'), npmPrefixDir)
+    createBootstrapClawprobe(path.join(globalBinDir, 'clawprobe'), stateFile)
+    setFakePath(fakePathDir)
+
+    const result = await clawprobeBootstrap()
+
+    assert.equal(result.ok, true)
+    assert.equal(result.alreadyRunning, false)
+    assert.equal(result.daemonRunning, true)
+    assert.equal(result.message, 'ClawProbe 已成功拉起')
+    assert.equal(fs.existsSync(stateFile), true)
+  }
+)


### PR DESCRIPTION
## Summary
- resolve `clawprobe` from the npm global prefix before falling back to a PATH-only lookup
- reuse the backend `clawprobe` resolver from `/api/exec` so setup detection and observe bootstrap share one execution path
- add backend coverage for both the exec route and bootstrap flow when `clawprobe` is installed globally but missing from `PATH`

## Testing
- `npm run test --workspace=@openclaw-manager/backend`
- `npm run build --workspace=@openclaw-manager/backend`
- `npm run test --workspace=@openclaw-manager/web -- ObservePage`
- `npx tsx --eval "import { runClawprobeCommand } from './packages/backend/src/execClawprobe.ts'; (async () => { const result = await runClawprobeCommand(['--version']); console.log(JSON.stringify(result)); })();"`

Refs #7