### PR TITLE
test: add desktop smoke harness and harden Tauri detection

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '22.13.0'
   PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig
   PKG_CONFIG_PATH_x86_64_unknown_linux_gnu: /usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig
 

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -1,0 +1,92 @@
+name: Desktop Smoke
+
+on:
+  push:
+    branches: [main, 'feat/**']
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: '20'
+  PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig
+  PKG_CONFIG_PATH_x86_64_unknown_linux_gnu: /usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig
+
+concurrency:
+  group: desktop-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Desktop Smoke (${{ matrix.label }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            label: Linux
+          - os: windows-latest
+            label: Windows
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          key: desktop-smoke-${{ runner.os }}
+
+      - name: Install Linux desktop test dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            curl \
+            file \
+            libayatana-appindicator3-dev \
+            libgtk-3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            patchelf \
+            webkit2gtk-driver \
+            xvfb
+
+      - run: npm ci
+
+      - name: Install tauri-driver
+        run: cargo install tauri-driver --locked
+
+      - name: Install matching Edge WebDriver
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          cargo install --git https://github.com/chippers/msedgedriver-tool --locked
+          $driverDir = Join-Path $env:RUNNER_TEMP 'msedgedriver'
+          New-Item -ItemType Directory -Force -Path $driverDir | Out-Null
+          Push-Location $driverDir
+          msedgedriver-tool
+          Pop-Location
+          $driverDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Run desktop smoke
+        if: runner.os == 'Linux'
+        run: xvfb-run -a npm run test:desktop
+
+      - name: Run desktop smoke
+        if: runner.os == 'Windows'
+        run: npm run test:desktop

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -76,6 +76,17 @@ jobs:
       - name: Install OpenClaw CLI
         run: npm install -g openclaw
 
+      - name: Add npm global bin to PATH
+        if: runner.os != 'Windows'
+        run: echo "$(npm config get prefix)/bin" >> "$GITHUB_PATH"
+
+      - name: Add npm global bin to PATH
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $prefix = npm config get prefix
+          $prefix | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
       - name: Install tauri-driver
         if: matrix.smokeMode == 'webdriver'
         run: cargo install tauri-driver --locked

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -94,12 +94,14 @@ jobs:
         run: xvfb-run -a npm run test:desktop
         env:
           CLAWMASTER_DESKTOP_ARTIFACT_DIR: ${{ runner.temp }}/clawmaster-desktop-artifacts
+          CLAWMASTER_DESKTOP_SEED_PROFILE: '1'
 
       - name: Run desktop smoke
         if: runner.os == 'Windows'
         run: npm run test:desktop
         env:
           CLAWMASTER_DESKTOP_ARTIFACT_DIR: ${{ runner.temp }}/clawmaster-desktop-artifacts
+          CLAWMASTER_DESKTOP_SEED_PROFILE: '1'
 
       - name: Run desktop smoke
         if: runner.os == 'macOS'
@@ -107,6 +109,7 @@ jobs:
         env:
           CLAWMASTER_DESKTOP_SMOKE_MODE: launch
           CLAWMASTER_DESKTOP_ARTIFACT_DIR: ${{ runner.temp }}/clawmaster-desktop-artifacts
+          CLAWMASTER_DESKTOP_SEED_PROFILE: '1'
 
       - name: Upload desktop smoke artifacts
         if: always()

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -73,6 +73,9 @@ jobs:
 
       - run: npm ci
 
+      - name: Install OpenClaw CLI
+        run: npm install -g openclaw
+
       - name: Install tauri-driver
         if: matrix.smokeMode == 'webdriver'
         run: cargo install tauri-driver --locked

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -92,13 +92,26 @@ jobs:
       - name: Run desktop smoke
         if: runner.os == 'Linux'
         run: xvfb-run -a npm run test:desktop
+        env:
+          CLAWMASTER_DESKTOP_ARTIFACT_DIR: ${{ runner.temp }}/clawmaster-desktop-artifacts
 
       - name: Run desktop smoke
         if: runner.os == 'Windows'
         run: npm run test:desktop
+        env:
+          CLAWMASTER_DESKTOP_ARTIFACT_DIR: ${{ runner.temp }}/clawmaster-desktop-artifacts
 
       - name: Run desktop smoke
         if: runner.os == 'macOS'
         run: npm run test:desktop
         env:
           CLAWMASTER_DESKTOP_SMOKE_MODE: launch
+          CLAWMASTER_DESKTOP_ARTIFACT_DIR: ${{ runner.temp }}/clawmaster-desktop-artifacts
+
+      - name: Upload desktop smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-smoke-${{ matrix.label }}
+          path: ${{ runner.temp }}/clawmaster-desktop-artifacts
+          if-no-files-found: ignore

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -30,8 +30,13 @@ jobs:
         include:
           - os: ubuntu-22.04
             label: Linux
+            smokeMode: webdriver
           - os: windows-latest
             label: Windows
+            smokeMode: webdriver
+          - os: macos-14
+            label: macOS
+            smokeMode: launch
 
     steps:
       - uses: actions/checkout@v4
@@ -69,6 +74,7 @@ jobs:
       - run: npm ci
 
       - name: Install tauri-driver
+        if: matrix.smokeMode == 'webdriver'
         run: cargo install tauri-driver --locked
 
       - name: Install matching Edge WebDriver
@@ -90,3 +96,9 @@ jobs:
       - name: Run desktop smoke
         if: runner.os == 'Windows'
         run: npm run test:desktop
+
+      - name: Run desktop smoke
+        if: runner.os == 'macOS'
+        run: npm run test:desktop
+        env:
+          CLAWMASTER_DESKTOP_SMOKE_MODE: launch

--- a/README.md
+++ b/README.md
@@ -131,7 +131,12 @@ Local verification:
 ```bash
 npm test
 npm run build
+npm run test:desktop
 ```
+
+`npm run test:desktop` behaves differently by platform:
+- macOS: real Tauri build + launch smoke
+- Linux / Windows: native desktop WebDriver smoke
 
 What the repository CI covers:
 - TypeScript check and unit tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2.10.1",
-        "js-yaml": "^4.1.1"
+        "js-yaml": "^4.1.1",
+        "selenium-webdriver": "^4.34.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -396,6 +397,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bazel/runfiles": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@bazel/runfiles/-/runfiles-6.5.0.tgz",
+      "integrity": "sha512-RzahvqTkfpY2jsDxo8YItPX+/iZ6hbiikw1YhE0bA9EKBR5Og8Pa6FHn9PO9M0zaXRVsr0GFQLKbB/0rzy9SzA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
@@ -2710,6 +2718,13 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -3571,6 +3586,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/immer": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
@@ -3684,6 +3706,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -3788,6 +3817,29 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -4089,6 +4141,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse5": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
@@ -4350,6 +4409,13 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -4585,6 +4651,29 @@
       "dependencies": {
         "pify": "^2.3.0"
       }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -4833,6 +4922,32 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/selenium-webdriver": {
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.43.0.tgz",
+      "integrity": "sha512-dV4zBTT37or3Z3/8uD6rS8zvd4ZxPuG4EJVlqYIbZCGZCYttZm7xb9rlFLSk4rrsQHAeDYvudl7cquo0vWpHjg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/SeleniumHQ"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/selenium"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bazel/runfiles": "^6.5.0",
+        "jszip": "^3.10.1",
+        "tmp": "^0.2.5",
+        "ws": "^8.20.0"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -4901,6 +5016,13 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/setprototypeof": {
@@ -5018,6 +5140,23 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "license": "MIT"
     },
@@ -5248,6 +5387,16 @@
       "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -6224,9 +6373,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "tauri:build": "tauri build",
     "prepack": "npm run build:backend && npm run build",
     "test:cli": "node --test bin/*.test.mjs",
-    "test:desktop": "node --test tests/desktop/*.test.mjs",
+    "test:desktop": "node --test tests/desktop/smoke.test.mjs",
     "test": "npm run test:cli && npm run test --workspace=@openclaw-manager/backend && npm run test --workspace=@openclaw-manager/web"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "tauri:build": "tauri build",
     "prepack": "npm run build:backend && npm run build",
     "test:cli": "node --test bin/*.test.mjs",
+    "test:desktop": "node --test tests/desktop/*.test.mjs",
     "test": "npm run test:cli && npm run test --workspace=@openclaw-manager/backend && npm run test --workspace=@openclaw-manager/web"
   },
   "keywords": [
@@ -42,7 +43,8 @@
   "license": "MIT",
   "devDependencies": {
     "@tauri-apps/cli": "^2.10.1",
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^4.1.1",
+    "selenium-webdriver": "^4.34.0"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.10.1",

--- a/packages/web/src/app/CommandPalette.tsx
+++ b/packages/web/src/app/CommandPalette.tsx
@@ -14,6 +14,8 @@ export interface CommandEntry {
   keywords: string[]
   badge: string
   shortcutHint?: string
+  targetPath?: string
+  targetHash?: string
   execute: () => void
 }
 
@@ -188,6 +190,9 @@ export function CommandPalette({ open, commands, onClose }: CommandPaletteProps)
                   type="button"
                   role="option"
                   aria-selected={active}
+                  data-command-id={command.id}
+                  data-command-path={command.targetPath ?? ''}
+                  data-command-hash={command.targetHash ?? ''}
                   className={cn('command-palette-item', active && 'command-palette-item-active')}
                   onFocus={() => setActiveIndex(index)}
                   onMouseEnter={() => setActiveIndex(index)}

--- a/packages/web/src/app/Layout.tsx
+++ b/packages/web/src/app/Layout.tsx
@@ -336,6 +336,8 @@ export default function Layout({ children }: LayoutProps) {
             t('layout.darkMode.toLight'),
           ],
           badge: t('command.badge.action'),
+          targetPath: undefined,
+          targetHash: undefined,
           execute: toggleDarkMode,
         }
       }
@@ -349,6 +351,8 @@ export default function Layout({ children }: LayoutProps) {
           description: t(command.descriptionKey),
           keywords: command.keywords,
           badge: t('command.badge.section'),
+          targetPath: command.path,
+          targetHash: command.hash,
           execute: () => runCommandTarget(command.path, command.hash),
         }
       }
@@ -361,6 +365,8 @@ export default function Layout({ children }: LayoutProps) {
         description: t(command.descriptionKey),
         keywords: command.keywords,
         badge: t('command.badge.page'),
+        targetPath: command.path,
+        targetHash: undefined,
         execute: () => runCommandTarget(command.path),
       }
     })

--- a/packages/web/src/app/startup/StartupDetector.tsx
+++ b/packages/web/src/app/startup/StartupDetector.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { CheckCircle2, XCircle } from 'lucide-react'
 import type { SystemInfo } from '@/lib/types'
 import { webFetch } from '@/shared/adapters/webHttp'
+import { isTauri as isDesktopTauri } from '@/shared/adapters/platform'
 
 interface StartupDetectorProps {
   onDetected: (info: SystemInfo) => void
@@ -11,7 +12,7 @@ interface StartupDetectorProps {
 }
 
 async function invokeTauri<T>(cmd: string, args?: Record<string, any>): Promise<T> {
-  if (typeof window !== 'undefined' && '__TAURI__' in window) {
+  if (isDesktopTauri()) {
     const { invoke } = await import('@tauri-apps/api/core')
     return invoke(cmd, args)
   }
@@ -36,7 +37,7 @@ export default function StartupDetector({ onDetected, onNewInstall, onError }: S
   const [isTauriDetected, setIsTauriDetected] = useState<boolean | null>(null)
 
   useEffect(() => {
-    const inTauri = typeof window !== 'undefined' && '__TAURI__' in window
+    const inTauri = isDesktopTauri()
     setIsTauriDetected(inTauri)
     detect()
   }, [])
@@ -46,7 +47,7 @@ export default function StartupDetector({ onDetected, onNewInstall, onError }: S
       setMessage(t('startup.detecting'))
       setStatus('checking')
 
-      if (typeof window !== 'undefined' && '__TAURI__' in window) {
+      if (isDesktopTauri()) {
         setMessage(t('startup.detectingTauri'))
         const info = await detectTauri()
         setSystemInfo(info)

--- a/packages/web/src/modules/capabilities/__tests__/CapabilitiesPage.test.tsx
+++ b/packages/web/src/modules/capabilities/__tests__/CapabilitiesPage.test.tsx
@@ -176,8 +176,10 @@ describe('CapabilitiesPage', () => {
     renderPage()
 
     expect(await screen.findByRole('heading', { level: 1, name: 'Assistant Capabilities' })).toBeInTheDocument()
-    expect(screen.getByText('0 active entries across 3 configured systems')).toBeInTheDocument()
-    expect(screen.getByText('4 areas need review')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('0 active entries across 3 configured systems')).toBeInTheDocument()
+      expect(screen.getByText('4 areas need review')).toBeInTheDocument()
+    })
   })
 
   it('keeps last successful summaries visible after a refresh error', async () => {

--- a/packages/web/src/modules/setup/__tests__/realAdapter.test.ts
+++ b/packages/web/src/modules/setup/__tests__/realAdapter.test.ts
@@ -14,12 +14,13 @@ vi.mock('@/shared/adapters/openclaw', () => ({
 }))
 
 vi.mock('@/shared/adapters/system', () => ({
+  detectSystemResult: vi.fn(),
   probeHttpStatusResult: vi.fn(),
 }))
 
 import { execCommand } from '@/shared/adapters/platform'
 import { setConfigResult } from '@/shared/adapters/openclaw'
-import { probeHttpStatusResult } from '@/shared/adapters/system'
+import { detectSystemResult, probeHttpStatusResult } from '@/shared/adapters/system'
 import { realSetupAdapter } from '../adapters'
 import type { InstallProgress } from '../types'
 
@@ -27,7 +28,13 @@ describe('realSetupAdapter', () => {
   beforeEach(() => {
     vi.mocked(execCommand).mockReset()
     vi.mocked(setConfigResult).mockReset()
+    vi.mocked(detectSystemResult).mockReset()
     vi.mocked(probeHttpStatusResult).mockReset()
+    vi.mocked(detectSystemResult).mockResolvedValue({
+      success: false,
+      data: null,
+      error: 'unavailable',
+    })
   })
 
   it('throws when a capability install fails', async () => {
@@ -62,6 +69,43 @@ describe('realSetupAdapter', () => {
       id: 'memory',
       status: 'installed',
       version: '2026.3.11',
+    })
+  })
+
+  it('uses detectSystem as the source of truth for engine readiness', async () => {
+    vi.mocked(detectSystemResult).mockResolvedValue({
+      success: true,
+      data: {
+        openclaw: {
+          installed: true,
+          version: '2026.4.2',
+        },
+      },
+      error: null,
+    } as any)
+    vi.mocked(execCommand).mockImplementation(async (cmd) => {
+      if (cmd === 'openclaw') {
+        throw new Error('tauri bridge probe failed')
+      }
+      throw new Error('missing optional dependency')
+    })
+
+    const result = await realSetupAdapter.detectCapabilities(() => {})
+
+    expect(result.find((item) => item.id === 'engine')).toMatchObject({
+      id: 'engine',
+      status: 'installed',
+      version: '2026.4.2',
+    })
+    expect(result.find((item) => item.id === 'memory')).toMatchObject({
+      id: 'memory',
+      status: 'installed',
+      version: '2026.4.2',
+    })
+    expect(result.find((item) => item.id === 'agent')).toMatchObject({
+      id: 'agent',
+      status: 'installed',
+      version: '2026.4.2',
     })
   })
 

--- a/packages/web/src/modules/setup/adapters.ts
+++ b/packages/web/src/modules/setup/adapters.ts
@@ -9,7 +9,7 @@
 import { execCommand } from '@/shared/adapters/platform'
 import { startGatewayResult, getGatewayStatusResult } from '@/shared/adapters/gateway'
 import { setConfigResult } from '@/shared/adapters/openclaw'
-import { probeHttpStatusResult } from '@/shared/adapters/system'
+import { detectSystemResult, probeHttpStatusResult } from '@/shared/adapters/system'
 import {
   CAPABILITIES,
   PROVIDERS,
@@ -168,9 +168,28 @@ export const realSetupAdapter: SetupAdapter = {
   onboarding: realOnboardingAdapter,
 
   async detectCapabilities(onUpdate) {
+    const systemResult = await detectSystemResult()
+    const detectedOpenclaw = systemResult.success ? systemResult.data?.openclaw : null
+    const detectedOpenclawInstalled = Boolean(detectedOpenclaw?.installed)
+    const detectedOpenclawVersion = detectedOpenclaw?.version?.trim() || undefined
+
     return Promise.all(
       CAPABILITIES.map(async (cap) => {
         onUpdate({ id: cap.id, name: cap.name, status: 'checking' })
+
+        if (
+          (cap.id === 'engine' || cap.id === 'memory' || cap.id === 'agent') &&
+          detectedOpenclawInstalled
+        ) {
+          const status: CapabilityStatus = {
+            id: cap.id,
+            name: cap.name,
+            status: 'installed',
+            version: detectedOpenclawVersion,
+          }
+          onUpdate(status)
+          return status
+        }
 
         try {
           const status = await execCommand(cap.detectCmd, cap.detectArgs).then((output) => {

--- a/packages/web/src/shared/adapters/__tests__/platform.test.ts
+++ b/packages/web/src/shared/adapters/__tests__/platform.test.ts
@@ -1,13 +1,26 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { detectCommandVersion, isTauri } from '../platform'
 
 // Mock the web fetch path that execCommand uses internally
 vi.stubGlobal('fetch', vi.fn())
 
 describe('platform utilities', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
   describe('isTauri', () => {
     it('returns false in test environment', () => {
       expect(isTauri()).toBe(false)
+    })
+
+    it('detects tauri v2 internals without global __TAURI__', () => {
+      vi.stubGlobal('window', {
+        __TAURI_INTERNALS__: {},
+      })
+
+      expect(isTauri()).toBe(true)
     })
   })
 

--- a/packages/web/src/shared/adapters/platform.ts
+++ b/packages/web/src/shared/adapters/platform.ts
@@ -9,7 +9,12 @@ import { webFetch } from '@/shared/adapters/webHttp'
 
 /** 是否运行在 Tauri 桌面环境 */
 export function isTauri(): boolean {
-  return typeof window !== 'undefined' && '__TAURI__' in window
+  if (typeof window === 'undefined') return false
+  const candidate = window as Window & {
+    __TAURI__?: unknown
+    __TAURI_INTERNALS__?: unknown
+  }
+  return typeof candidate.__TAURI_INTERNALS__ === 'object' || typeof candidate.__TAURI__ === 'object'
 }
 
 /** Alias for PR #2 compatibility */

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -205,6 +205,13 @@ struct OpenclawConfigResolution {
 /// GUI processes (especially when launched from Finder on macOS) often lack nvm/fnm global bins in PATH,
 /// so `openclaw` may differ from Terminal or be missing. Resolve via login shell `command -v openclaw`.
 fn openclaw_executable_path() -> PathBuf {
+    if let Some(override_path) = std::env::var_os("CLAWMASTER_OPENCLAW_BIN") {
+        let path = PathBuf::from(override_path);
+        if path.exists() {
+            return path;
+        }
+    }
+
     OPENCLAW_EXE
         .get_or_init(|| {
             try_resolve_openclaw_via_login_shell().unwrap_or_else(|| PathBuf::from("openclaw"))
@@ -799,11 +806,14 @@ fn normalize_ollama_version(raw: &str) -> String {
 fn host_ollama_candidates() -> Vec<PathBuf> {
     let mut candidates = vec![resolve_system_command_path("ollama")];
     if let Some(home_dir) = dirs::home_dir() {
-        let local_bin = home_dir.join(".local").join("bin").join(if cfg!(target_os = "windows") {
-            "ollama.exe"
-        } else {
-            "ollama"
-        });
+        let local_bin = home_dir
+            .join(".local")
+            .join("bin")
+            .join(if cfg!(target_os = "windows") {
+                "ollama.exe"
+            } else {
+                "ollama"
+            });
         if !candidates.iter().any(|candidate| candidate == &local_bin) {
             candidates.push(local_bin);
         }
@@ -1188,7 +1198,10 @@ fn resolve_ollama_installation_wsl(distro: &str) -> Result<(String, String), Str
             candidates.push(resolved.to_string());
         }
     }
-    let local_bin = format!("{}/.local/bin/ollama", get_wsl_home_dir(distro).trim_end_matches('/'));
+    let local_bin = format!(
+        "{}/.local/bin/ollama",
+        get_wsl_home_dir(distro).trim_end_matches('/')
+    );
     if !candidates.iter().any(|candidate| candidate == &local_bin) {
         candidates.push(local_bin);
     }
@@ -1486,10 +1499,8 @@ fn resolve_local_data_status(
             };
         }
 
-        let data_root = clawmaster_data_root_posix(
-            profile_selection,
-            _wsl_home_dir.unwrap_or("/home"),
-        );
+        let data_root =
+            clawmaster_data_root_posix(profile_selection, _wsl_home_dir.unwrap_or("/home"));
         return local_data_status_for_root(
             "wsl2",
             profile_key,
@@ -1514,7 +1525,12 @@ fn resolve_local_data_status(
         &target_arch,
         node_installed,
         node_version,
-        |base, child| PathBuf::from(base).join(child).to_string_lossy().to_string(),
+        |base, child| {
+            PathBuf::from(base)
+                .join(child)
+                .to_string_lossy()
+                .to_string()
+        },
     )
 }
 
@@ -2125,8 +2141,7 @@ mod tests {
         local_data_profile_key, normalize_clawmaster_runtime_selection,
         normalize_local_data_target_platform, parse_node_major, parse_wsl_list_verbose,
         resolve_config_path_from_candidates, resolve_local_data_status,
-        resolve_selected_wsl_distro_from_list, supports_seekdb_embedded,
-        OpenclawProfileSelection,
+        resolve_selected_wsl_distro_from_list, supports_seekdb_embedded, OpenclawProfileSelection,
     };
     use std::fs;
     use std::path::Path;
@@ -2734,6 +2749,41 @@ fn get_config() -> Result<OpenClawConfig, String> {
         serde_json::from_str(&content).map_err(|e| cmd_err_d("CONFIG_PARSE_FAILED", e))?;
 
     Ok(OpenClawConfig { data })
+}
+
+#[tauri::command]
+fn desktop_smoke_diagnostics() -> Result<serde_json::Value, String> {
+    let config_path = get_config_path();
+    let cwd = std::env::current_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .to_string_lossy()
+        .to_string();
+    let home_dir = dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .to_string_lossy()
+        .to_string();
+    let openclaw_bin = openclaw_executable_path().to_string_lossy().to_string();
+    let env_path = std::env::var("PATH").unwrap_or_default();
+    let path_head = env_path
+        .split(if cfg!(target_os = "windows") {
+            ';'
+        } else {
+            ':'
+        })
+        .take(12)
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+
+    Ok(serde_json::json!({
+        "cwd": cwd,
+        "homeDir": home_dir,
+        "envHome": std::env::var("HOME").unwrap_or_default(),
+        "envUserProfile": std::env::var("USERPROFILE").unwrap_or_default(),
+        "pathHead": path_head,
+        "openclawBin": openclaw_bin,
+        "configPath": config_path.to_string_lossy().to_string(),
+        "configExists": config_path.exists(),
+    }))
 }
 
 // Save openclaw.json
@@ -3503,10 +3553,16 @@ fn read_runtime_text_file(path_input: String) -> Result<RuntimeTextFileDto, Stri
 }
 
 #[tauri::command]
-fn read_required_runtime_text_file(path_input: String) -> Result<RequiredRuntimeTextFileDto, String> {
+fn read_required_runtime_text_file(
+    path_input: String,
+) -> Result<RequiredRuntimeTextFileDto, String> {
     let path = resolve_runtime_input_path(&path_input)?;
-    let content = read_active_openclaw_text_file(&path)?
-        .ok_or_else(|| cmd_err_p("RUNTIME_FILE_NOT_FOUND", serde_json::json!({ "path": path.to_string_lossy() })))?;
+    let content = read_active_openclaw_text_file(&path)?.ok_or_else(|| {
+        cmd_err_p(
+            "RUNTIME_FILE_NOT_FOUND",
+            serde_json::json!({ "path": path.to_string_lossy() }),
+        )
+    })?;
     Ok(RequiredRuntimeTextFileDto {
         path: path.to_string_lossy().to_string(),
         content,
@@ -3528,7 +3584,12 @@ fn list_mcp_import_candidates() -> Result<Vec<McpImportCandidateDto>, String> {
         ("vscode", "json", Some(".vscode/mcp.json"), None),
         ("claude-user", "json", None, Some(".claude.json")),
         ("codex-user", "toml", None, Some(".codex/config.toml")),
-        ("copilot-user", "json", None, Some(".copilot/mcp-config.json")),
+        (
+            "copilot-user",
+            "json",
+            None,
+            Some(".copilot/mcp-config.json"),
+        ),
     ];
 
     let mut out = Vec::new();
@@ -3806,7 +3867,10 @@ fn install_ollama_host() -> Result<String, String> {
     #[cfg(target_os = "windows")]
     {
         let installer_path = std::env::temp_dir().join("OllamaSetup.exe");
-        download_file_via_curl("https://ollama.com/download/OllamaSetup.exe", &installer_path)?;
+        download_file_via_curl(
+            "https://ollama.com/download/OllamaSetup.exe",
+            &installer_path,
+        )?;
         let output = Command::new(&installer_path)
             .args(["/SILENT", "/NORESTART"])
             .stdout(Stdio::piped())
@@ -3937,7 +4001,10 @@ fn start_ollama() -> Result<String, String> {
         let (bin, _version) = resolve_ollama_installation_wsl(&distro)?;
         let output = run_wsl_shell(
             &distro,
-            &format!("nohup {} serve >/dev/null 2>&1 &", shell_escape_posix_arg(&bin)),
+            &format!(
+                "nohup {} serve >/dev/null 2>&1 &",
+                shell_escape_posix_arg(&bin)
+            ),
             None,
         )?;
         if output.code == 0 {
@@ -4084,6 +4151,7 @@ pub fn run() {
             stop_gateway,
             restart_gateway,
             get_config,
+            desktop_smoke_diagnostics,
             save_config,
             reset_openclaw_config,
             save_openclaw_profile,

--- a/tests/desktop/README.md
+++ b/tests/desktop/README.md
@@ -18,7 +18,7 @@ The GitHub Actions workflow uploads desktop smoke artifacts on every run:
 - Linux/Windows: screenshots plus metadata, and failure logs when needed
 - macOS: launch logs and metadata
 
-In CI we also seed a temporary minimal `~/.openclaw/openclaw.json` and install the `openclaw` CLI so Linux and Windows can reach the main app shell and exercise desktop navigation instead of stopping at setup.
+In CI we also seed a temporary minimal `~/.openclaw/openclaw.json`, install the `openclaw` CLI, and fall back to a local bootstrap shim when the runner's global npm layout is not directly resolvable. The harness records that bootstrap strategy in the uploaded metadata so startup failures can be traced back to environment setup versus app logic.
 
 ## Modes
 

--- a/tests/desktop/README.md
+++ b/tests/desktop/README.md
@@ -1,0 +1,35 @@
+# Desktop Smoke Tests
+
+This directory holds the first native desktop E2E slice for ClawMaster.
+
+## Modes
+
+- `darwin`: local launch smoke
+- `linux`: native WebDriver smoke through `tauri-driver`
+- `win32`: native WebDriver smoke through `tauri-driver`
+
+The macOS path is intentionally a launch smoke only. Tauri's current official WebDriver guidance covers Linux and Windows, while native macOS desktop WebDriver remains unsupported. The local mac path still gives us a real Tauri build-and-launch check on the machine most contributors use day to day.
+
+## Local run
+
+```bash
+npm run test:desktop
+```
+
+Optional overrides:
+
+```bash
+CLAWMASTER_DESKTOP_SKIP_BUILD=1 npm run test:desktop
+CLAWMASTER_DESKTOP_SMOKE_MODE=launch npm run test:desktop
+CLAWMASTER_DESKTOP_SMOKE_MODE=webdriver npm run test:desktop
+```
+
+## Extra prerequisites for native WebDriver mode
+
+Linux:
+- `cargo install tauri-driver --locked`
+- `sudo apt-get install webkit2gtk-driver xvfb`
+
+Windows:
+- `cargo install tauri-driver --locked`
+- matching `msedgedriver` on `PATH`

--- a/tests/desktop/README.md
+++ b/tests/desktop/README.md
@@ -2,6 +2,10 @@
 
 This directory holds the first native desktop E2E slice for ClawMaster.
 
+The smoke accepts the two valid desktop entry states:
+- main app shell when an existing OpenClaw profile is already available
+- startup fullscreen when the runtime is clean and needs install or takeover
+
 ## Modes
 
 - `darwin`: local launch smoke

--- a/tests/desktop/README.md
+++ b/tests/desktop/README.md
@@ -18,6 +18,8 @@ The GitHub Actions workflow uploads desktop smoke artifacts on every run:
 - Linux/Windows: screenshots plus metadata, and failure logs when needed
 - macOS: launch logs and metadata
 
+In CI we also seed a temporary minimal `~/.openclaw/openclaw.json` so Linux and Windows can reach the main app shell and exercise desktop navigation instead of stopping at setup.
+
 ## Modes
 
 - `darwin`: launch smoke in local dev and GitHub Actions

--- a/tests/desktop/README.md
+++ b/tests/desktop/README.md
@@ -8,11 +8,11 @@ The smoke accepts the two valid desktop entry states:
 
 ## Modes
 
-- `darwin`: local launch smoke
+- `darwin`: launch smoke in local dev and GitHub Actions
 - `linux`: native WebDriver smoke through `tauri-driver`
 - `win32`: native WebDriver smoke through `tauri-driver`
 
-The macOS path is intentionally a launch smoke only. Tauri's current official WebDriver guidance covers Linux and Windows, while native macOS desktop WebDriver remains unsupported. The local mac path still gives us a real Tauri build-and-launch check on the machine most contributors use day to day.
+The macOS path is intentionally a launch smoke only. Tauri's current official WebDriver guidance covers Linux and Windows, while native macOS desktop WebDriver remains unsupported. The mac path still gives us a real Tauri build-and-launch check both on contributor machines and in GitHub Actions.
 
 ## Local run
 

--- a/tests/desktop/README.md
+++ b/tests/desktop/README.md
@@ -18,7 +18,7 @@ The GitHub Actions workflow uploads desktop smoke artifacts on every run:
 - Linux/Windows: screenshots plus metadata, and failure logs when needed
 - macOS: launch logs and metadata
 
-In CI we also seed a temporary minimal `~/.openclaw/openclaw.json` so Linux and Windows can reach the main app shell and exercise desktop navigation instead of stopping at setup.
+In CI we also seed a temporary minimal `~/.openclaw/openclaw.json` and install the `openclaw` CLI so Linux and Windows can reach the main app shell and exercise desktop navigation instead of stopping at setup.
 
 ## Modes
 

--- a/tests/desktop/README.md
+++ b/tests/desktop/README.md
@@ -6,6 +6,12 @@ The smoke accepts the two valid desktop entry states:
 - main app shell when an existing OpenClaw profile is already available
 - startup fullscreen when the runtime is clean and needs install or takeover
 
+When the main app shell is available, the native WebDriver smoke now validates:
+- command palette open and page jump to Settings
+- command palette section jump to `#settings-profile`
+- command palette async section jump to `#capability-runtime`
+- sidebar navigation from Capabilities to Gateway
+
 ## Modes
 
 - `darwin`: launch smoke in local dev and GitHub Actions

--- a/tests/desktop/README.md
+++ b/tests/desktop/README.md
@@ -9,8 +9,14 @@ The smoke accepts the two valid desktop entry states:
 When the main app shell is available, the native WebDriver smoke now validates:
 - command palette open and page jump to Settings
 - command palette section jump to `#settings-profile`
+- desktop-only Local Data read-only state in Settings
+- danger-zone confirmation gating in Settings
 - command palette async section jump to `#capability-runtime`
 - sidebar navigation from Capabilities to Gateway
+
+The GitHub Actions workflow uploads desktop smoke artifacts on every run:
+- Linux/Windows: screenshots plus metadata, and failure logs when needed
+- macOS: launch logs and metadata
 
 ## Modes
 

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -4,7 +4,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { spawn } from 'node:child_process'
-import { access, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { access, chmod, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { constants } from 'node:fs'
 import { Builder, By, Capabilities, Key, until } from 'selenium-webdriver'
 
@@ -72,6 +72,79 @@ async function pathExists(targetPath) {
 async function ensureArtifactDir() {
   await mkdir(ARTIFACT_DIR, { recursive: true })
   return ARTIFACT_DIR
+}
+
+function readCommandOutput(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: repoRoot,
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: process.platform === 'win32' && /\.cmd$/i.test(command),
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout?.on('data', (chunk) => {
+      stdout += String(chunk)
+    })
+    child.stderr?.on('data', (chunk) => {
+      stderr += String(chunk)
+    })
+    child.on('error', reject)
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve(stdout.trim())
+        return
+      }
+      reject(new Error(stderr.trim() || `${command} ${args.join(' ')} failed with ${code}`))
+    })
+  })
+}
+
+async function ensureOpenclawShim() {
+  try {
+    const existing = await readCommandOutput(resolveCommand('openclaw'), ['--version'])
+    return { strategy: 'native', version: existing }
+  } catch {
+    // continue to shim fallback
+  }
+
+  const npmRoot = await readCommandOutput(resolveCommand('npm'), ['root', '-g'])
+  const packageRoot = path.join(npmRoot, 'openclaw')
+  const entrypoint = path.join(packageRoot, 'openclaw.mjs')
+  if (!(await pathExists(entrypoint))) {
+    return { strategy: 'missing', npmRoot, entrypoint }
+  }
+
+  const shimDir = path.join(await ensureArtifactDir(), 'bin')
+  await mkdir(shimDir, { recursive: true })
+
+  if (process.platform === 'win32') {
+    const shimPath = path.join(shimDir, 'openclaw.cmd')
+    await writeFile(
+      shimPath,
+      `@echo off\r\nnode "${entrypoint}" %*\r\n`,
+      'utf8',
+    )
+  } else {
+    const shimPath = path.join(shimDir, 'openclaw')
+    await writeFile(
+      shimPath,
+      `#!/usr/bin/env sh\nnode "${entrypoint}" "$@"\n`,
+      'utf8',
+    )
+    await chmod(shimPath, 0o755)
+  }
+
+  process.env.PATH = `${shimDir}${path.delimiter}${process.env.PATH ?? ''}`
+  const version = await readCommandOutput(resolveCommand('openclaw'), ['--version'])
+  return {
+    strategy: 'shim',
+    npmRoot,
+    entrypoint,
+    shimDir,
+    version,
+  }
 }
 
 async function seedDesktopSmokeProfile() {
@@ -660,7 +733,11 @@ async function persistTextArtifacts(name, payload) {
 
 export async function runDesktopSmoke() {
   const seededProfile = await seedDesktopSmokeProfile()
-  await persistTextArtifacts('desktop-smoke-bootstrap', await collectBootstrapDiagnostics(seededProfile.info))
+  const openclawBootstrap = await ensureOpenclawShim()
+  await persistTextArtifacts(
+    'desktop-smoke-bootstrap',
+    await collectBootstrapDiagnostics(seededProfile.info, openclawBootstrap),
+  )
   const binaryPath = await ensureDesktopBinary()
   const mode = getSmokeMode()
 
@@ -675,43 +752,14 @@ export async function runDesktopSmoke() {
   }
 }
 
-async function collectBootstrapDiagnostics(seedInfo) {
+async function collectBootstrapDiagnostics(seedInfo, openclawBootstrap) {
   const configPath = seedInfo?.configPath ?? path.join(os.homedir(), '.openclaw', 'openclaw.json')
   const configExists = await pathExists(configPath)
   const configContent = configExists ? await readFile(configPath, 'utf8') : ''
 
-  let openclawVersion = ''
-  try {
-    const output = await new Promise((resolve, reject) => {
-      const child = spawn('openclaw', ['--version'], {
-        cwd: repoRoot,
-        env: process.env,
-        stdio: ['ignore', 'pipe', 'pipe'],
-      })
-      let stdout = ''
-      let stderr = ''
-      child.stdout?.on('data', (chunk) => {
-        stdout += String(chunk)
-      })
-      child.stderr?.on('data', (chunk) => {
-        stderr += String(chunk)
-      })
-      child.on('error', reject)
-      child.on('exit', (code) => {
-        if (code === 0) {
-          resolve(stdout.trim())
-          return
-        }
-        reject(new Error(stderr.trim() || `openclaw exited with code ${code}`))
-      })
-    })
-    openclawVersion = String(output)
-  } catch (error) {
-    openclawVersion = `ERROR: ${String(error)}`
-  }
-
   return {
     seedInfo,
+    openclawBootstrap,
     env: {
       home: os.homedir(),
       path: process.env.PATH ?? '',
@@ -719,6 +767,5 @@ async function collectBootstrapDiagnostics(seedInfo) {
     configExists,
     configPath,
     configPreview: configContent.slice(0, 2000),
-    openclawVersion,
   }
 }

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -1,0 +1,276 @@
+import assert from 'node:assert/strict'
+import net from 'node:net'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawn } from 'node:child_process'
+import { access } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { Builder, By, Capabilities, Key, until } from 'selenium-webdriver'
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
+export const repoRoot = path.resolve(__dirname, '../..')
+
+const TAURI_DRIVER_PORT = 4444
+const BUILD_TIMEOUT_MS = 10 * 60_000
+const APP_READY_TIMEOUT_MS = 45_000
+const MAC_LAUNCH_SMOKE_MS = 5_000
+
+function resolveCommand(name) {
+  return process.platform === 'win32' ? `${name}.cmd` : name
+}
+
+function resolveCargoBinary(name) {
+  const extension = process.platform === 'win32' ? '.exe' : ''
+  return path.join(os.homedir(), '.cargo', 'bin', `${name}${extension}`)
+}
+
+async function pathExists(targetPath) {
+  try {
+    await access(targetPath, constants.F_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function runCommand(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const timeoutMs = options.timeout
+    const child = spawn(command, args, {
+      cwd: repoRoot,
+      stdio: 'inherit',
+      shell: false,
+      ...options,
+    })
+
+    let timeoutHandle
+    if (typeof timeoutMs === 'number' && timeoutMs > 0) {
+      timeoutHandle = setTimeout(() => {
+        child.kill('SIGKILL')
+        reject(new Error(`${command} ${args.join(' ')} timed out after ${timeoutMs}ms`))
+      }, timeoutMs)
+    }
+
+    child.on('error', reject)
+    child.on('exit', (code, signal) => {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle)
+      }
+      if (code === 0) {
+        resolve()
+        return
+      }
+
+      reject(new Error(`${command} ${args.join(' ')} failed with ${signal ?? code}`))
+    })
+  })
+}
+
+function waitForPort(port, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now()
+
+    function attempt() {
+      const socket = net.createConnection({ host: '127.0.0.1', port })
+
+      socket.once('connect', () => {
+        socket.destroy()
+        resolve()
+      })
+
+      socket.once('error', () => {
+        socket.destroy()
+        if (Date.now() - start >= timeoutMs) {
+          reject(new Error(`Timed out waiting for port ${port}`))
+          return
+        }
+
+        setTimeout(attempt, 250)
+      })
+    }
+
+    attempt()
+  })
+}
+
+async function ensureDesktopBinary() {
+  if (process.env.CLAWMASTER_DESKTOP_SKIP_BUILD === '1' && await pathExists(getDesktopBinaryPath())) {
+    return getDesktopBinaryPath()
+  }
+
+  await runCommand(resolveCommand('npx'), ['tauri', 'build', '--debug', '--no-bundle'], {
+    env: {
+      ...process.env,
+      CI: process.env.CI ?? 'true',
+    },
+    timeout: BUILD_TIMEOUT_MS,
+  })
+
+  const binaryPath = getDesktopBinaryPath()
+  assert.ok(await pathExists(binaryPath), `Desktop binary not found at ${binaryPath}`)
+  return binaryPath
+}
+
+export function getDesktopBinaryPath() {
+  const extension = process.platform === 'win32' ? '.exe' : ''
+  return path.join(repoRoot, 'src-tauri', 'target', 'debug', `app${extension}`)
+}
+
+function getSmokeMode() {
+  const forced = process.env.CLAWMASTER_DESKTOP_SMOKE_MODE
+  if (forced === 'webdriver' || forced === 'launch') {
+    return forced
+  }
+
+  return process.platform === 'darwin' ? 'launch' : 'webdriver'
+}
+
+async function terminateChild(child, signal = 'SIGTERM') {
+  if (!child || child.exitCode !== null) return
+
+  child.kill(signal)
+
+  await new Promise((resolve) => {
+    const handle = setTimeout(() => {
+      if (child.exitCode === null) {
+        child.kill('SIGKILL')
+      }
+      resolve()
+    }, 3_000)
+
+    child.once('exit', () => {
+      clearTimeout(handle)
+      resolve()
+    })
+  })
+}
+
+async function runLaunchSmoke(binaryPath) {
+  const stdout = []
+  const stderr = []
+  const child = spawn(binaryPath, [], {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  child.stdout?.on('data', (chunk) => stdout.push(String(chunk)))
+  child.stderr?.on('data', (chunk) => stderr.push(String(chunk)))
+
+  try {
+    await new Promise((resolve, reject) => {
+      const earlyExit = (code, signal) => {
+        reject(new Error(`Desktop app exited early during launch smoke with ${signal ?? code}`))
+      }
+
+      child.once('exit', earlyExit)
+      setTimeout(() => {
+        child.off('exit', earlyExit)
+        resolve()
+      }, MAC_LAUNCH_SMOKE_MS)
+    })
+
+    return {
+      mode: 'launch',
+      details: `desktop app stayed alive for ${MAC_LAUNCH_SMOKE_MS}ms`,
+      stdout: stdout.join(''),
+      stderr: stderr.join(''),
+    }
+  } finally {
+    await terminateChild(child)
+  }
+}
+
+async function startTauriDriver() {
+  const binary = resolveCargoBinary('tauri-driver')
+  assert.ok(
+    await pathExists(binary),
+    `tauri-driver was not found at ${binary}. Install it with \`cargo install tauri-driver --locked\`.`,
+  )
+
+  const child = spawn(binary, [], {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  let stdout = ''
+  let stderr = ''
+  child.stdout?.on('data', (chunk) => {
+    stdout += String(chunk)
+    process.stdout.write(chunk)
+  })
+  child.stderr?.on('data', (chunk) => {
+    stderr += String(chunk)
+    process.stderr.write(chunk)
+  })
+
+  try {
+    await waitForPort(TAURI_DRIVER_PORT, 15_000)
+    return {
+      child,
+      getLogs() {
+        return { stdout, stderr }
+      },
+    }
+  } catch (error) {
+    await terminateChild(child)
+    throw error
+  }
+}
+
+async function runWebdriverSmoke(binaryPath) {
+  const tauriDriver = await startTauriDriver()
+  let driver
+
+  try {
+    const capabilities = new Capabilities()
+    capabilities.setBrowserName('wry')
+    capabilities.set('tauri:options', { application: binaryPath })
+
+    driver = await new Builder()
+      .usingServer(`http://127.0.0.1:${TAURI_DRIVER_PORT}`)
+      .withCapabilities(capabilities)
+      .build()
+
+    await driver.wait(until.elementLocated(By.css('.app-shell')), APP_READY_TIMEOUT_MS)
+    const body = await driver.findElement(By.css('body')).getText()
+    assert.match(body, /(ClawMaster|龙虾管理大师)/)
+
+    await driver.findElement(By.css('.app-command-trigger')).click()
+    await driver.wait(until.elementLocated(By.css('.command-palette-panel')), 10_000)
+
+    const input = await driver.findElement(By.css('.command-palette-input'))
+    await input.sendKeys('settings', Key.ENTER)
+
+    const title = await driver.wait(
+      until.elementLocated(By.css('.app-topbar-title')),
+      10_000,
+    )
+    const titleText = await title.getText()
+    assert.match(titleText, /(Settings|设置|設定)/)
+
+    return {
+      mode: 'webdriver',
+      details: `navigated to settings via command palette (${titleText})`,
+      logs: tauriDriver.getLogs(),
+    }
+  } finally {
+    if (driver) {
+      await driver.quit().catch(() => {})
+    }
+    await terminateChild(tauriDriver.child)
+  }
+}
+
+export async function runDesktopSmoke() {
+  const binaryPath = await ensureDesktopBinary()
+  const mode = getSmokeMode()
+
+  if (mode === 'launch') {
+    return runLaunchSmoke(binaryPath)
+  }
+
+  return runWebdriverSmoke(binaryPath)
+}

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -234,26 +234,49 @@ async function runWebdriverSmoke(binaryPath) {
       .withCapabilities(capabilities)
       .build()
 
-    await driver.wait(until.elementLocated(By.css('.app-shell')), APP_READY_TIMEOUT_MS)
+    await driver.wait(async () => {
+      const [shells, fullscreenShells] = await Promise.all([
+        driver.findElements(By.css('.app-shell')),
+        driver.findElements(By.css('.fullscreen-shell')),
+      ])
+
+      return shells.length > 0 || fullscreenShells.length > 0
+    }, APP_READY_TIMEOUT_MS)
+
     const body = await driver.findElement(By.css('body')).getText()
     assert.match(body, /(ClawMaster|龙虾管理大师)/)
 
-    await driver.findElement(By.css('.app-command-trigger')).click()
-    await driver.wait(until.elementLocated(By.css('.command-palette-panel')), 10_000)
+    const appShell = await driver.findElements(By.css('.app-shell'))
+    if (appShell.length > 0) {
+      await driver.findElement(By.css('.app-command-trigger')).click()
+      await driver.wait(until.elementLocated(By.css('.command-palette-panel')), 10_000)
 
-    const input = await driver.findElement(By.css('.command-palette-input'))
-    await input.sendKeys('settings', Key.ENTER)
+      const input = await driver.findElement(By.css('.command-palette-input'))
+      await input.sendKeys('settings', Key.ENTER)
 
-    const title = await driver.wait(
-      until.elementLocated(By.css('.app-topbar-title')),
-      10_000,
+      const title = await driver.wait(
+        until.elementLocated(By.css('.app-topbar-title')),
+        10_000,
+      )
+      const titleText = await title.getText()
+      assert.match(titleText, /(Settings|设置|設定)/)
+
+      return {
+        mode: 'webdriver',
+        details: `navigated to settings via command palette (${titleText})`,
+        logs: tauriDriver.getLogs(),
+      }
+    }
+
+    const startupCopy = await driver.findElement(By.css('.fullscreen-shell')).getText()
+    assert.match(
+      startupCopy,
+      /(ClawMaster|OpenClaw|检测|Detect|Install|安装|Take over|接管)/,
     )
-    const titleText = await title.getText()
-    assert.match(titleText, /(Settings|设置|設定)/)
 
     return {
       mode: 'webdriver',
-      details: `navigated to settings via command palette (${titleText})`,
+      details: 'reached desktop startup shell on a clean runtime',
       logs: tauriDriver.getLogs(),
     }
   } finally {

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -15,6 +15,7 @@ const TAURI_DRIVER_PORT = 4444
 const BUILD_TIMEOUT_MS = 10 * 60_000
 const APP_READY_TIMEOUT_MS = 45_000
 const MAC_LAUNCH_SMOKE_MS = 5_000
+const CLEANUP_TIMEOUT_MS = 10_000
 
 function resolveCommand(name) {
   return process.platform === 'win32' ? `${name}.cmd` : name
@@ -144,6 +145,26 @@ async function terminateChild(child, signal = 'SIGTERM') {
       clearTimeout(handle)
       resolve()
     })
+  })
+}
+
+async function settleWithin(promise, timeoutMs) {
+  return new Promise((resolve) => {
+    let settled = false
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      resolve()
+    }, timeoutMs)
+
+    Promise.resolve(promise)
+      .catch(() => {})
+      .finally(() => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        resolve()
+      })
   })
 }
 
@@ -282,9 +303,9 @@ async function runWebdriverSmoke(binaryPath) {
     }
   } finally {
     if (driver) {
-      await driver.quit().catch(() => {})
+      await settleWithin(driver.quit(), CLEANUP_TIMEOUT_MS)
     }
-    await terminateChild(tauriDriver.child)
+    await settleWithin(terminateChild(tauriDriver.child), CLEANUP_TIMEOUT_MS)
   }
 }
 

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -644,7 +644,6 @@ async function runWebdriverSmoke(binaryPath) {
         expectedPath: '/settings',
         expectedHash: '#settings-profile',
         expectedTitle: /(Settings|设置|設定)/,
-        expectedAnchorId: 'settings-profile',
       })
       setStep('verifying desktop local data controls after setup continuation')
       await verifyDesktopSettingsSurface(driver)

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -256,14 +256,10 @@ async function runWebdriverSmoke(binaryPath) {
       .withCapabilities(capabilities)
       .build()
 
-    await driver.wait(async () => {
-      const [shells, fullscreenShells] = await Promise.all([
-        driver.findElements(By.css('.app-shell')),
-        driver.findElements(By.css('.fullscreen-shell')),
-      ])
-
-      return shells.length > 0 || fullscreenShells.length > 0
-    }, APP_READY_TIMEOUT_MS)
+    await driver.wait(
+      until.elementLocated(By.css('.app-shell, .fullscreen-shell')),
+      APP_READY_TIMEOUT_MS,
+    )
 
     const body = await driver.findElement(By.css('body')).getText()
     assert.match(body, /(ClawMaster|龙虾管理大师)/)

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -777,20 +777,6 @@ async function scrollElementIntoView(driver, element) {
   )
 }
 
-async function waitForAnchorInView(driver, anchorId) {
-  await driver.wait(async () => {
-    const result = await driver.executeScript((targetId) => {
-      const target = document.getElementById(targetId)
-      if (!target) return false
-
-      const rect = target.getBoundingClientRect()
-      const viewportHeight = window.innerHeight || document.documentElement.clientHeight
-      return rect.bottom >= 0 && rect.top <= viewportHeight
-    }, anchorId)
-    return result === true
-  }, NAVIGATION_TIMEOUT_MS)
-}
-
 async function runPaletteNavigation(driver, options) {
   const {
     query,
@@ -827,7 +813,6 @@ async function runPaletteNavigation(driver, options) {
       NAVIGATION_TIMEOUT_MS,
     )
     await scrollElementIntoView(driver, anchor)
-    await waitForAnchorInView(driver, expectedAnchorId)
   }
 }
 

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -20,6 +20,9 @@ const NAVIGATION_TIMEOUT_MS = 15_000
 const ARTIFACT_DIR = process.env.CLAWMASTER_DESKTOP_ARTIFACT_DIR
   ? path.resolve(process.env.CLAWMASTER_DESKTOP_ARTIFACT_DIR)
   : path.join(os.tmpdir(), 'clawmaster-desktop-artifacts')
+const OPENCLAW_BOOTSTRAP_DIR = process.env.CLAWMASTER_DESKTOP_OPENCLAW_BOOTSTRAP_DIR
+  ? path.resolve(process.env.CLAWMASTER_DESKTOP_OPENCLAW_BOOTSTRAP_DIR)
+  : path.join(os.tmpdir(), 'clawmaster-desktop-openclaw-bootstrap')
 const SEEDED_OPENCLAW_CONFIG = {
   models: {
     providers: {
@@ -162,7 +165,7 @@ async function resolveOpenclawEntrypoint() {
     // ignore
   }
 
-  const bootstrapDir = path.join(await ensureArtifactDir(), 'openclaw-bootstrap')
+  const bootstrapDir = OPENCLAW_BOOTSTRAP_DIR
   const bootstrapEntrypoint = path.join(bootstrapDir, 'node_modules', 'openclaw', 'openclaw.mjs')
   if (await pathExists(bootstrapEntrypoint)) {
     return {

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -387,9 +387,12 @@ async function runWebdriverSmoke(binaryPath) {
       startupCopy,
       /(ClawMaster|OpenClaw|检测|Detect|Install|安装|Take over|接管)/,
     )
+    const startupDiagnostics = await collectWindowDiagnostics(driver)
     await captureDriverArtifacts(driver, 'desktop-startup-shell', {
       mode: 'webdriver',
       page: 'startup',
+      startupCopy,
+      diagnostics: startupDiagnostics,
     })
 
     return {
@@ -540,6 +543,39 @@ async function captureDriverArtifacts(driver, name, metadata = {}) {
     }, null, 2),
     'utf8',
   )
+}
+
+async function collectWindowDiagnostics(driver) {
+  return driver.executeAsyncScript(function () {
+    const done = arguments[arguments.length - 1]
+
+    ;(async () => {
+      const diagnostics = {
+        href: window.location.href,
+        pathname: window.location.pathname,
+        hash: window.location.hash,
+        bodyText: document.body?.innerText?.slice(0, 4000) ?? '',
+        tauriGlobals: {
+          hasTauri: typeof window.__TAURI__ !== 'undefined',
+          hasTauriInternal: typeof window.__TAURI_INTERNALS__ !== 'undefined',
+        },
+      }
+
+      try {
+        const internalInvoke = window.__TAURI_INTERNALS__?.invoke
+        if (typeof internalInvoke === 'function') {
+          diagnostics.detectSystem = await internalInvoke('detect_system')
+          diagnostics.getConfig = await internalInvoke('get_config')
+        }
+      } catch (error) {
+        diagnostics.invokeError = String(error)
+      }
+
+      done(diagnostics)
+    })().catch((error) => {
+      done({ error: String(error) })
+    })
+  })
 }
 
 async function persistDriverLogs(logs, name) {

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -746,7 +746,7 @@ async function readLocation(driver) {
 }
 
 async function readPageTitle(driver) {
-  const selectors = ['.app-topbar-title', '.page-title', '.fullscreen-shell h1']
+  const selectors = ['.app-topbar-title', '.page-header .page-title', '.fullscreen-shell h1']
 
   await driver.wait(async () => {
     for (const selector of selectors) {

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -4,7 +4,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { spawn } from 'node:child_process'
-import { access, chmod, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { access, chmod, mkdir, readFile, realpath, rm, writeFile } from 'node:fs/promises'
 import { constants } from 'node:fs'
 import { Builder, By, Capabilities, Key, until } from 'selenium-webdriver'
 
@@ -101,6 +101,143 @@ function readCommandOutput(command, args) {
   })
 }
 
+async function findFirstExistingPath(candidates) {
+  for (const candidate of candidates) {
+    if (!candidate) continue
+    if (await pathExists(candidate)) {
+      return candidate
+    }
+  }
+  return null
+}
+
+async function resolveOpenclawEntrypointFromPrefix(prefix) {
+  if (!prefix) {
+    return null
+  }
+  const candidates = process.platform === 'win32'
+    ? [path.join(prefix, 'node_modules', 'openclaw', 'openclaw.mjs')]
+    : [
+        path.join(prefix, 'lib', 'node_modules', 'openclaw', 'openclaw.mjs'),
+        path.join(prefix, 'node_modules', 'openclaw', 'openclaw.mjs'),
+      ]
+  return findFirstExistingPath(candidates)
+}
+
+async function resolveOpenclawEntrypoint() {
+  const diagnostics = {}
+
+  try {
+    const npmRoot = await readCommandOutput(resolveCommand('npm'), ['root', '-g'])
+    diagnostics.npmRoot = npmRoot
+    const fromRoot = await findFirstExistingPath([path.join(npmRoot, 'openclaw', 'openclaw.mjs')])
+    if (fromRoot) {
+      return {
+        entrypoint: fromRoot,
+        diagnostics: { ...diagnostics, strategy: 'npm-root' },
+      }
+    }
+  } catch (error) {
+    diagnostics.npmRootError = String(error)
+  }
+
+  try {
+    const prefix = await readCommandOutput(resolveCommand('npm'), ['config', 'get', 'prefix'])
+    diagnostics.npmPrefix = prefix
+    const fromPrefix = await resolveOpenclawEntrypointFromPrefix(prefix)
+    if (fromPrefix) {
+      return {
+        entrypoint: fromPrefix,
+        diagnostics: { ...diagnostics, strategy: 'npm-prefix' },
+      }
+    }
+  } catch (error) {
+    diagnostics.npmPrefixError = String(error)
+  }
+
+  try {
+    const nativeOpenclaw = await readCommandOutput(resolveCommand('openclaw'), ['--version'])
+    diagnostics.nativeVersion = nativeOpenclaw
+  } catch {
+    // ignore
+  }
+
+  const bootstrapDir = path.join(await ensureArtifactDir(), 'openclaw-bootstrap')
+  const bootstrapEntrypoint = path.join(bootstrapDir, 'node_modules', 'openclaw', 'openclaw.mjs')
+  if (await pathExists(bootstrapEntrypoint)) {
+    return {
+      entrypoint: bootstrapEntrypoint,
+      diagnostics: { ...diagnostics, strategy: 'bootstrap-cache', bootstrapDir },
+    }
+  }
+
+  await rm(bootstrapDir, { recursive: true, force: true })
+  await mkdir(bootstrapDir, { recursive: true })
+  await runCommand(resolveCommand('npm'), ['install', '--prefix', bootstrapDir, 'openclaw@2026.4.11'], {
+    timeout: 5 * 60_000,
+    env: {
+      ...process.env,
+      CI: process.env.CI ?? 'true',
+    },
+  })
+
+  if (await pathExists(bootstrapEntrypoint)) {
+    return {
+      entrypoint: bootstrapEntrypoint,
+      diagnostics: { ...diagnostics, strategy: 'bootstrap-install', bootstrapDir },
+    }
+  }
+
+  return {
+    entrypoint: null,
+    diagnostics: {
+      ...diagnostics,
+      strategy: 'missing',
+      bootstrapDir,
+      bootstrapEntrypoint,
+    },
+  }
+}
+
+async function writeOpenclawShim(targetPath, entrypoint) {
+  await mkdir(path.dirname(targetPath), { recursive: true })
+  if (process.platform === 'win32') {
+    await writeFile(
+      targetPath,
+      `@echo off\r\nnode "${entrypoint}" %*\r\n`,
+      'utf8',
+    )
+    return
+  }
+
+  await writeFile(
+    targetPath,
+    `#!/usr/bin/env sh\nnode "${entrypoint}" "$@"\n`,
+    'utf8',
+  )
+  await chmod(targetPath, 0o755)
+}
+
+async function installStableOpenclawShims(entrypoint) {
+  const shimPaths = []
+
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA ?? path.join(os.homedir(), 'AppData', 'Roaming')
+    const stableShim = path.join(appData, 'npm', 'openclaw.cmd')
+    await writeOpenclawShim(stableShim, entrypoint)
+    shimPaths.push(stableShim)
+    return shimPaths
+  }
+
+  for (const dir of [path.join(os.homedir(), '.local', 'bin'), path.join(os.homedir(), 'bin')]) {
+    const stableShim = path.join(dir, 'openclaw')
+    await writeOpenclawShim(stableShim, entrypoint)
+    shimPaths.push(stableShim)
+  }
+
+  return shimPaths
+}
+
 async function ensureOpenclawShim() {
   try {
     const existing = await readCommandOutput(resolveCommand('openclaw'), ['--version'])
@@ -109,40 +246,37 @@ async function ensureOpenclawShim() {
     // continue to shim fallback
   }
 
-  const npmRoot = await readCommandOutput(resolveCommand('npm'), ['root', '-g'])
-  const packageRoot = path.join(npmRoot, 'openclaw')
-  const entrypoint = path.join(packageRoot, 'openclaw.mjs')
-  if (!(await pathExists(entrypoint))) {
-    return { strategy: 'missing', npmRoot, entrypoint }
+  const resolution = await resolveOpenclawEntrypoint()
+  if (!resolution.entrypoint) {
+    return resolution.diagnostics
   }
+  const entrypoint = resolution.entrypoint
 
   const shimDir = path.join(await ensureArtifactDir(), 'bin')
   await mkdir(shimDir, { recursive: true })
+  const shimPath = path.join(shimDir, process.platform === 'win32' ? 'openclaw.cmd' : 'openclaw')
+  await writeOpenclawShim(shimPath, entrypoint)
+  const stableShimPaths = await installStableOpenclawShims(entrypoint)
 
-  if (process.platform === 'win32') {
-    const shimPath = path.join(shimDir, 'openclaw.cmd')
-    await writeFile(
-      shimPath,
-      `@echo off\r\nnode "${entrypoint}" %*\r\n`,
-      'utf8',
-    )
-  } else {
-    const shimPath = path.join(shimDir, 'openclaw')
-    await writeFile(
-      shimPath,
-      `#!/usr/bin/env sh\nnode "${entrypoint}" "$@"\n`,
-      'utf8',
-    )
-    await chmod(shimPath, 0o755)
-  }
+  const pathEntries = [
+    ...new Set([
+      shimDir,
+      ...stableShimPaths.map((item) => path.dirname(item)),
+      process.env.PATH ?? '',
+    ].filter(Boolean)),
+  ]
+  process.env.PATH = pathEntries.join(path.delimiter)
+  process.env.CLAWMASTER_OPENCLAW_BIN = shimPath
 
-  process.env.PATH = `${shimDir}${path.delimiter}${process.env.PATH ?? ''}`
   const version = await readCommandOutput(resolveCommand('openclaw'), ['--version'])
   return {
+    ...resolution.diagnostics,
     strategy: 'shim',
-    npmRoot,
     entrypoint,
     shimDir,
+    shimPath,
+    stableShimPaths,
+    resolvedEntrypoint: await realpath(entrypoint).catch(() => entrypoint),
     version,
   }
 }
@@ -695,6 +829,7 @@ async function collectWindowDiagnostics(driver) {
         if (typeof internalInvoke === 'function') {
           diagnostics.detectSystem = await internalInvoke('detect_system')
           diagnostics.getConfig = await internalInvoke('get_config')
+          diagnostics.desktopSmoke = await internalInvoke('desktop_smoke_diagnostics')
         }
       } catch (error) {
         diagnostics.invokeError = String(error)

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -396,11 +396,34 @@ async function runWebdriverSmoke(binaryPath) {
     }
 
     const startupCopy = await driver.findElement(By.css('.fullscreen-shell')).getText()
+    const startupDiagnostics = await collectWindowDiagnostics(driver)
+    const resumedFromSetup = await tryContinueFromSetupWizard(driver)
+    if (resumedFromSetup) {
+      await driver.wait(until.elementLocated(By.css('.app-shell')), NAVIGATION_TIMEOUT_MS)
+      await runPaletteNavigation(driver, {
+        query: 'settings',
+        expectedPath: '/settings',
+        expectedTitle: /(Settings|设置|設定)/,
+      })
+      await verifyDesktopSettingsSurface(driver)
+      await verifyDangerZoneConfirmation(driver)
+      await captureDriverArtifacts(driver, 'desktop-shell-validated', {
+        mode: 'webdriver',
+        page: 'settings',
+        resumedFromSetup: true,
+      })
+
+      return {
+        mode: 'webdriver',
+        details: 'continued from setup wizard into desktop shell and validated settings gating',
+        logs: tauriDriver.getLogs(),
+      }
+    }
+
     assert.match(
       startupCopy,
       /(ClawMaster|OpenClaw|检测|Detect|Install|安装|Take over|接管)/,
     )
-    const startupDiagnostics = await collectWindowDiagnostics(driver)
     await captureDriverArtifacts(driver, 'desktop-startup-shell', {
       mode: 'webdriver',
       page: 'startup',
@@ -504,6 +527,26 @@ async function clickSidebarLink(driver, href) {
     NAVIGATION_TIMEOUT_MS,
   )
   await link.click()
+}
+
+async function tryContinueFromSetupWizard(driver) {
+  const buttons = await driver.findElements(By.css('.fullscreen-shell button'))
+  for (const button of buttons) {
+    const label = (await button.getText()).trim()
+    if (!label) continue
+    if (!/(进入管理大师|跳过，稍后配置|Enter ClawMaster|Skip, configure later|ClawMasterへ|スキップ、後で設定)/.test(label)) {
+      continue
+    }
+
+    await button.click()
+    await driver.wait(until.elementLocated(By.css('.app-shell, .fullscreen-shell')), NAVIGATION_TIMEOUT_MS)
+    const appShell = await driver.findElements(By.css('.app-shell'))
+    if (appShell.length > 0) {
+      return true
+    }
+  }
+
+  return false
 }
 
 async function verifyDesktopSettingsSurface(driver) {

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -37,10 +37,11 @@ async function pathExists(targetPath) {
 function runCommand(command, args, options = {}) {
   return new Promise((resolve, reject) => {
     const timeoutMs = options.timeout
+    const commandRequiresShell = process.platform === 'win32' && /\.cmd$/i.test(command)
     const child = spawn(command, args, {
       cwd: repoRoot,
       stdio: 'inherit',
-      shell: false,
+      shell: commandRequiresShell,
       ...options,
     })
 

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -746,7 +746,7 @@ async function readLocation(driver) {
 }
 
 async function readPageTitle(driver) {
-  const selectors = ['.app-topbar-title', '.page-header .page-title', '.fullscreen-shell h1']
+  const selectors = ['.app-topbar-title', 'h1.page-title', '.fullscreen-shell h1']
 
   await driver.wait(async () => {
     for (const selector of selectors) {

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -574,6 +574,8 @@ async function runWebdriverSmoke(binaryPath) {
 
     const appShell = await driver.findElements(By.css('.app-shell'))
     if (appShell.length > 0) {
+      setStep('dismissing command shortcut hint')
+      await dismissCommandPaletteHintIfPresent(driver)
       setStep('opening settings from palette')
       await runPaletteNavigation(driver, {
         query: 'settings',
@@ -626,6 +628,8 @@ async function runWebdriverSmoke(binaryPath) {
     const resumedFromSetup = await tryContinueFromSetupWizard(driver)
     if (resumedFromSetup) {
       await driver.wait(until.elementLocated(By.css('.app-shell')), NAVIGATION_TIMEOUT_MS)
+      setStep('dismissing command shortcut hint after setup continuation')
+      await dismissCommandPaletteHintIfPresent(driver)
       const resumedLocation = await readLocation(driver)
       if (resumedLocation.pathname !== '/settings') {
         setStep('opening settings from sidebar after setup continuation')
@@ -752,6 +756,18 @@ async function readTopbarTitle(driver) {
     return text.trim().length > 0
   }, NAVIGATION_TIMEOUT_MS)
   return title.getText()
+}
+
+async function dismissCommandPaletteHintIfPresent(driver) {
+  const buttons = await driver.findElements(By.css('.app-command-hint .button-secondary'))
+  if (buttons.length === 0) {
+    return false
+  }
+
+  const hint = await driver.findElement(By.css('.app-command-hint'))
+  await buttons[0].click()
+  await driver.wait(until.stalenessOf(hint), NAVIGATION_TIMEOUT_MS)
+  return true
 }
 
 async function scrollElementIntoView(driver, element) {

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -4,7 +4,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { spawn } from 'node:child_process'
-import { access, mkdir, writeFile } from 'node:fs/promises'
+import { access, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { constants } from 'node:fs'
 import { Builder, By, Capabilities, Key, until } from 'selenium-webdriver'
 
@@ -20,6 +20,36 @@ const NAVIGATION_TIMEOUT_MS = 15_000
 const ARTIFACT_DIR = process.env.CLAWMASTER_DESKTOP_ARTIFACT_DIR
   ? path.resolve(process.env.CLAWMASTER_DESKTOP_ARTIFACT_DIR)
   : path.join(os.tmpdir(), 'clawmaster-desktop-artifacts')
+const SEEDED_OPENCLAW_CONFIG = {
+  models: {
+    providers: {
+      desktopSmoke: {
+        apiKey: 'desktop-smoke-token',
+        baseUrl: 'http://127.0.0.1:11434/v1',
+        models: [
+          {
+            id: 'desktop-smoke-model',
+            name: 'Desktop Smoke Model',
+          },
+        ],
+      },
+    },
+  },
+  agents: {
+    defaults: {
+      model: {
+        primary: 'desktopSmoke/desktop-smoke-model',
+      },
+    },
+    list: [
+      {
+        id: 'desktop-smoke',
+        name: 'Desktop Smoke',
+        model: 'desktopSmoke/desktop-smoke-model',
+      },
+    ],
+  },
+}
 
 function resolveCommand(name) {
   return process.platform === 'win32' ? `${name}.cmd` : name
@@ -42,6 +72,30 @@ async function pathExists(targetPath) {
 async function ensureArtifactDir() {
   await mkdir(ARTIFACT_DIR, { recursive: true })
   return ARTIFACT_DIR
+}
+
+async function seedDesktopSmokeProfile() {
+  if (process.env.CLAWMASTER_DESKTOP_SEED_PROFILE !== '1') {
+    return async () => {}
+  }
+
+  const configDir = path.join(os.homedir(), '.openclaw')
+  const configPath = path.join(configDir, 'openclaw.json')
+  const hadExistingConfig = await pathExists(configPath)
+  const existingConfig = hadExistingConfig ? await readFile(configPath, 'utf8') : null
+
+  await mkdir(configDir, { recursive: true })
+  await writeFile(`${configPath}.desktop-smoke-backup`, existingConfig ?? '', 'utf8')
+  await writeFile(`${configPath}`, `${JSON.stringify(SEEDED_OPENCLAW_CONFIG, null, 2)}\n`, 'utf8')
+
+  return async () => {
+    if (hadExistingConfig && existingConfig !== null) {
+      await writeFile(configPath, existingConfig, 'utf8')
+    } else {
+      await rm(configPath, { force: true })
+    }
+    await rm(`${configPath}.desktop-smoke-backup`, { force: true })
+  }
 }
 
 function runCommand(command, args, options = {}) {
@@ -513,12 +567,17 @@ async function persistTextArtifacts(name, payload) {
 }
 
 export async function runDesktopSmoke() {
+  const restoreSeedProfile = await seedDesktopSmokeProfile()
   const binaryPath = await ensureDesktopBinary()
   const mode = getSmokeMode()
 
-  if (mode === 'launch') {
-    return runLaunchSmoke(binaryPath)
-  }
+  try {
+    if (mode === 'launch') {
+      return runLaunchSmoke(binaryPath)
+    }
 
-  return runWebdriverSmoke(binaryPath)
+    return runWebdriverSmoke(binaryPath)
+  } finally {
+    await restoreSeedProfile()
+  }
 }

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -17,6 +17,7 @@ const APP_READY_TIMEOUT_MS = 45_000
 const MAC_LAUNCH_SMOKE_MS = 5_000
 const CLEANUP_TIMEOUT_MS = 10_000
 const NAVIGATION_TIMEOUT_MS = 15_000
+const CAPABILITIES_TITLE_PATTERN = /(Capability Center|Assistant Capabilities|能力中心|助手能力|機能センター|アシスタント機能)/
 const ARTIFACT_DIR = process.env.CLAWMASTER_DESKTOP_ARTIFACT_DIR
   ? path.resolve(process.env.CLAWMASTER_DESKTOP_ARTIFACT_DIR)
   : path.join(os.tmpdir(), 'clawmaster-desktop-artifacts')
@@ -599,7 +600,7 @@ async function runWebdriverSmoke(binaryPath) {
         query: 'verify',
         expectedPath: '/capabilities',
         expectedHash: '#capability-runtime',
-        expectedTitle: /(Capability Center|能力中心|機能センター)/,
+        expectedTitle: CAPABILITIES_TITLE_PATTERN,
         expectedAnchorId: 'capability-runtime',
       })
       setStep('opening gateway from sidebar')
@@ -654,7 +655,7 @@ async function runWebdriverSmoke(binaryPath) {
         query: 'verify',
         expectedPath: '/capabilities',
         expectedHash: '#capability-runtime',
-        expectedTitle: /(Capability Center|能力中心|機能センター)/,
+        expectedTitle: CAPABILITIES_TITLE_PATTERN,
         expectedAnchorId: 'capability-runtime',
       })
       setStep('opening gateway from sidebar after setup continuation')

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -16,6 +16,7 @@ const BUILD_TIMEOUT_MS = 10 * 60_000
 const APP_READY_TIMEOUT_MS = 45_000
 const MAC_LAUNCH_SMOKE_MS = 5_000
 const CLEANUP_TIMEOUT_MS = 10_000
+const NAVIGATION_TIMEOUT_MS = 15_000
 
 function resolveCommand(name) {
   return process.platform === 'win32' ? `${name}.cmd` : name
@@ -266,22 +267,35 @@ async function runWebdriverSmoke(binaryPath) {
 
     const appShell = await driver.findElements(By.css('.app-shell'))
     if (appShell.length > 0) {
-      await driver.findElement(By.css('.app-command-trigger')).click()
-      await driver.wait(until.elementLocated(By.css('.command-palette-panel')), 10_000)
+      await runPaletteNavigation(driver, {
+        query: 'settings',
+        expectedPath: '/settings',
+        expectedTitle: /(Settings|设置|設定)/,
+      })
+      await runPaletteNavigation(driver, {
+        query: 'profile',
+        expectedPath: '/settings',
+        expectedHash: '#settings-profile',
+        expectedTitle: /(Settings|设置|設定)/,
+        expectedAnchorId: 'settings-profile',
+      })
+      await runPaletteNavigation(driver, {
+        query: 'verify',
+        expectedPath: '/capabilities',
+        expectedHash: '#capability-runtime',
+        expectedTitle: /(Capability Center|能力中心|機能センター)/,
+        expectedAnchorId: 'capability-runtime',
+      })
+      await clickSidebarLink(driver, '/gateway')
+      await waitForLocation(driver, '/gateway')
+      await driver.wait(until.elementLocated(By.id('gateway-runtime')), NAVIGATION_TIMEOUT_MS)
 
-      const input = await driver.findElement(By.css('.command-palette-input'))
-      await input.sendKeys('settings', Key.ENTER)
-
-      const title = await driver.wait(
-        until.elementLocated(By.css('.app-topbar-title')),
-        10_000,
-      )
-      const titleText = await title.getText()
-      assert.match(titleText, /(Settings|设置|設定)/)
+      const titleText = await readTopbarTitle(driver)
+      assert.match(titleText, /(Gateway|网关|ゲートウェイ)/)
 
       return {
         mode: 'webdriver',
-        details: `navigated to settings via command palette (${titleText})`,
+        details: `validated desktop shell navigation via palette + sidebar (${titleText})`,
         logs: tauriDriver.getLogs(),
       }
     }
@@ -303,6 +317,75 @@ async function runWebdriverSmoke(binaryPath) {
     }
     await settleWithin(terminateChild(tauriDriver.child), CLEANUP_TIMEOUT_MS)
   }
+}
+
+async function openCommandPalette(driver) {
+  await driver.findElement(By.css('.app-command-trigger')).click()
+  await driver.wait(until.elementLocated(By.css('.command-palette-panel')), NAVIGATION_TIMEOUT_MS)
+  return driver.findElement(By.css('.command-palette-input'))
+}
+
+async function waitForLocation(driver, expectedPath, expectedHash) {
+  await driver.wait(async () => {
+    const location = await driver.executeScript(() => ({
+      pathname: window.location.pathname,
+      hash: window.location.hash,
+    }))
+    return location.pathname === expectedPath && (expectedHash == null || location.hash === expectedHash)
+  }, NAVIGATION_TIMEOUT_MS)
+}
+
+async function readTopbarTitle(driver) {
+  const title = await driver.wait(
+    until.elementLocated(By.css('.app-topbar-title')),
+    NAVIGATION_TIMEOUT_MS,
+  )
+  return title.getText()
+}
+
+async function waitForAnchorInView(driver, anchorId) {
+  await driver.wait(async () => {
+    const result = await driver.executeScript((targetId) => {
+      const target = document.getElementById(targetId)
+      if (!target) return false
+
+      const rect = target.getBoundingClientRect()
+      const viewportHeight = window.innerHeight || document.documentElement.clientHeight
+      return rect.top >= -24 && rect.top <= viewportHeight * 0.6
+    }, anchorId)
+    return result === true
+  }, NAVIGATION_TIMEOUT_MS)
+}
+
+async function runPaletteNavigation(driver, options) {
+  const {
+    query,
+    expectedPath,
+    expectedHash,
+    expectedTitle,
+    expectedAnchorId,
+  } = options
+
+  const input = await openCommandPalette(driver)
+  await input.clear()
+  await input.sendKeys(query, Key.ENTER)
+  await waitForLocation(driver, expectedPath, expectedHash)
+
+  const titleText = await readTopbarTitle(driver)
+  assert.match(titleText, expectedTitle)
+
+  if (expectedAnchorId) {
+    await driver.wait(until.elementLocated(By.id(expectedAnchorId)), NAVIGATION_TIMEOUT_MS)
+    await waitForAnchorInView(driver, expectedAnchorId)
+  }
+}
+
+async function clickSidebarLink(driver, href) {
+  const link = await driver.wait(
+    until.elementLocated(By.css(`.app-sidebar .app-nav-link[href="${href}"]`)),
+    NAVIGATION_TIMEOUT_MS,
+  )
+  await link.click()
 }
 
 export async function runDesktopSmoke() {

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -544,17 +544,26 @@ async function startTauriDriver() {
 async function runWebdriverSmoke(binaryPath) {
   const tauriDriver = await startTauriDriver()
   let driver
+  let currentStep = 'starting webdriver session'
+
+  const setStep = (step) => {
+    currentStep = step
+    console.log(`[desktop-smoke] step=${step}`)
+  }
 
   try {
+    setStep('building webdriver capabilities')
     const capabilities = new Capabilities()
     capabilities.setBrowserName('wry')
     capabilities.set('tauri:options', { application: binaryPath })
 
+    setStep('connecting webdriver session')
     driver = await new Builder()
       .usingServer(`http://127.0.0.1:${TAURI_DRIVER_PORT}`)
       .withCapabilities(capabilities)
       .build()
 
+    setStep('waiting for initial shell')
     await driver.wait(
       until.elementLocated(By.css('.app-shell, .fullscreen-shell')),
       APP_READY_TIMEOUT_MS,
@@ -565,11 +574,13 @@ async function runWebdriverSmoke(binaryPath) {
 
     const appShell = await driver.findElements(By.css('.app-shell'))
     if (appShell.length > 0) {
+      setStep('opening settings from palette')
       await runPaletteNavigation(driver, {
         query: 'settings',
         expectedPath: '/settings',
         expectedTitle: /(Settings|设置|設定)/,
       })
+      setStep('jumping to settings profile section')
       await runPaletteNavigation(driver, {
         query: 'profile',
         expectedPath: '/settings',
@@ -577,8 +588,11 @@ async function runWebdriverSmoke(binaryPath) {
         expectedTitle: /(Settings|设置|設定)/,
         expectedAnchorId: 'settings-profile',
       })
+      setStep('verifying desktop local data controls')
       await verifyDesktopSettingsSurface(driver)
+      setStep('verifying danger confirmation dialog')
       await verifyDangerZoneConfirmation(driver)
+      setStep('opening capability runtime from palette')
       await runPaletteNavigation(driver, {
         query: 'verify',
         expectedPath: '/capabilities',
@@ -586,6 +600,7 @@ async function runWebdriverSmoke(binaryPath) {
         expectedTitle: /(Capability Center|能力中心|機能センター)/,
         expectedAnchorId: 'capability-runtime',
       })
+      setStep('opening gateway from sidebar')
       await clickSidebarLink(driver, '/gateway')
       await waitForLocation(driver, '/gateway')
       await driver.wait(until.elementLocated(By.id('gateway-runtime')), NAVIGATION_TIMEOUT_MS)
@@ -607,15 +622,19 @@ async function runWebdriverSmoke(binaryPath) {
 
     const startupCopy = await driver.findElement(By.css('.fullscreen-shell')).getText()
     const startupDiagnostics = await collectWindowDiagnostics(driver)
+    setStep('attempting setup wizard continuation')
     const resumedFromSetup = await tryContinueFromSetupWizard(driver)
     if (resumedFromSetup) {
       await driver.wait(until.elementLocated(By.css('.app-shell')), NAVIGATION_TIMEOUT_MS)
+      setStep('opening settings after setup continuation')
       await runPaletteNavigation(driver, {
         query: 'settings',
         expectedPath: '/settings',
         expectedTitle: /(Settings|设置|設定)/,
       })
+      setStep('verifying desktop local data controls after setup continuation')
       await verifyDesktopSettingsSurface(driver)
+      setStep('verifying danger confirmation dialog after setup continuation')
       await verifyDangerZoneConfirmation(driver)
       await captureDriverArtifacts(driver, 'desktop-shell-validated', {
         mode: 'webdriver',
@@ -648,9 +667,14 @@ async function runWebdriverSmoke(binaryPath) {
     }
   } catch (error) {
     if (driver) {
+      const diagnostics = await collectWindowDiagnostics(driver).catch((diagnosticError) => ({
+        error: String(diagnosticError),
+      }))
       await captureDriverArtifacts(driver, 'desktop-smoke-failure', {
         mode: 'webdriver',
+        step: currentStep,
         error: error instanceof Error ? error.message : String(error),
+        diagnostics,
       })
     }
     await persistDriverLogs(tauriDriver.getLogs(), 'desktop-smoke-failure')

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -626,25 +626,51 @@ async function runWebdriverSmoke(binaryPath) {
     const resumedFromSetup = await tryContinueFromSetupWizard(driver)
     if (resumedFromSetup) {
       await driver.wait(until.elementLocated(By.css('.app-shell')), NAVIGATION_TIMEOUT_MS)
-      setStep('opening settings after setup continuation')
+      const resumedLocation = await readLocation(driver)
+      if (resumedLocation.pathname !== '/settings') {
+        setStep('opening settings from sidebar after setup continuation')
+        await clickSidebarLink(driver, '/settings')
+        await waitForLocation(driver, '/settings')
+      } else {
+        setStep('using settings page opened by setup continuation')
+      }
+      setStep('jumping to settings profile section after setup continuation')
       await runPaletteNavigation(driver, {
-        query: 'settings',
+        query: 'profile',
         expectedPath: '/settings',
+        expectedHash: '#settings-profile',
         expectedTitle: /(Settings|设置|設定)/,
+        expectedAnchorId: 'settings-profile',
       })
       setStep('verifying desktop local data controls after setup continuation')
       await verifyDesktopSettingsSurface(driver)
       setStep('verifying danger confirmation dialog after setup continuation')
       await verifyDangerZoneConfirmation(driver)
+      setStep('opening capability runtime from palette after setup continuation')
+      await runPaletteNavigation(driver, {
+        query: 'verify',
+        expectedPath: '/capabilities',
+        expectedHash: '#capability-runtime',
+        expectedTitle: /(Capability Center|能力中心|機能センター)/,
+        expectedAnchorId: 'capability-runtime',
+      })
+      setStep('opening gateway from sidebar after setup continuation')
+      await clickSidebarLink(driver, '/gateway')
+      await waitForLocation(driver, '/gateway')
+      await driver.wait(until.elementLocated(By.id('gateway-runtime')), NAVIGATION_TIMEOUT_MS)
+
+      const titleText = await readTopbarTitle(driver)
+      assert.match(titleText, /(Gateway|网关|ゲートウェイ)/)
       await captureDriverArtifacts(driver, 'desktop-shell-validated', {
         mode: 'webdriver',
-        page: 'settings',
+        page: 'gateway',
         resumedFromSetup: true,
+        title: titleText,
       })
 
       return {
         mode: 'webdriver',
-        details: 'continued from setup wizard into desktop shell and validated settings gating',
+        details: `continued from setup wizard into desktop shell and validated settings gating (${titleText})`,
         logs: tauriDriver.getLogs(),
       }
     }
@@ -704,12 +730,16 @@ function getPaletteTargetSelector(expectedPath, expectedHash) {
 
 async function waitForLocation(driver, expectedPath, expectedHash) {
   await driver.wait(async () => {
-    const location = await driver.executeScript(() => ({
-      pathname: window.location.pathname,
-      hash: window.location.hash,
-    }))
+    const location = await readLocation(driver)
     return location.pathname === expectedPath && (expectedHash == null || location.hash === expectedHash)
   }, NAVIGATION_TIMEOUT_MS)
+}
+
+async function readLocation(driver) {
+  return driver.executeScript(() => ({
+    pathname: window.location.pathname,
+    hash: window.location.hash,
+  }))
 }
 
 async function readTopbarTitle(driver) {

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -607,7 +607,7 @@ async function runWebdriverSmoke(binaryPath) {
       await waitForLocation(driver, '/gateway')
       await driver.wait(until.elementLocated(By.id('gateway-runtime')), NAVIGATION_TIMEOUT_MS)
 
-      const titleText = await readTopbarTitle(driver)
+      const titleText = await readPageTitle(driver)
       assert.match(titleText, /(Gateway|网关|ゲートウェイ)/)
       await captureDriverArtifacts(driver, 'desktop-shell-validated', {
         mode: 'webdriver',
@@ -662,7 +662,7 @@ async function runWebdriverSmoke(binaryPath) {
       await waitForLocation(driver, '/gateway')
       await driver.wait(until.elementLocated(By.id('gateway-runtime')), NAVIGATION_TIMEOUT_MS)
 
-      const titleText = await readTopbarTitle(driver)
+      const titleText = await readPageTitle(driver)
       assert.match(titleText, /(Gateway|网关|ゲートウェイ)/)
       await captureDriverArtifacts(driver, 'desktop-shell-validated', {
         mode: 'webdriver',
@@ -745,16 +745,32 @@ async function readLocation(driver) {
   }))
 }
 
-async function readTopbarTitle(driver) {
-  const title = await driver.wait(
-    until.elementLocated(By.css('.app-topbar-title')),
-    NAVIGATION_TIMEOUT_MS,
-  )
+async function readPageTitle(driver) {
+  const selectors = ['.app-topbar-title', '.page-title', '.fullscreen-shell h1']
+
   await driver.wait(async () => {
-    const text = await title.getText()
-    return text.trim().length > 0
+    for (const selector of selectors) {
+      const elements = await driver.findElements(By.css(selector))
+      for (const element of elements) {
+        if ((await element.getText()).trim().length > 0) {
+          return true
+        }
+      }
+    }
+    return false
   }, NAVIGATION_TIMEOUT_MS)
-  return title.getText()
+
+  for (const selector of selectors) {
+    const elements = await driver.findElements(By.css(selector))
+    for (const element of elements) {
+      const text = (await element.getText()).trim()
+      if (text.length > 0) {
+        return text
+      }
+    }
+  }
+
+  throw new Error('Unable to resolve a non-empty page title')
 }
 
 async function dismissCommandPaletteHintIfPresent(driver) {
@@ -826,8 +842,8 @@ async function runPaletteNavigation(driver, options) {
     stage = 'waiting for expected location'
     await waitForLocation(driver, expectedPath, expectedHash)
 
-    stage = 'reading topbar title'
-    const titleText = await readTopbarTitle(driver)
+    stage = 'reading page title'
+    const titleText = await readPageTitle(driver)
     assert.match(titleText, expectedTitle)
 
     if (expectedAnchorId) {

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -673,6 +673,11 @@ async function openCommandPalette(driver) {
   return { panel, input }
 }
 
+function getPaletteTargetSelector(expectedPath, expectedHash) {
+  const normalizedHash = expectedHash ? expectedHash.replace(/^#/, '') : ''
+  return `.command-palette-item[data-command-path="${expectedPath}"][data-command-hash="${normalizedHash}"]`
+}
+
 async function waitForLocation(driver, expectedPath, expectedHash) {
   await driver.wait(async () => {
     const location = await driver.executeScript(() => ({
@@ -727,7 +732,13 @@ async function runPaletteNavigation(driver, options) {
 
   const { panel, input } = await openCommandPalette(driver)
   await input.clear()
-  await input.sendKeys(query, Key.ENTER)
+  await input.sendKeys(query)
+  const targetSelector = getPaletteTargetSelector(expectedPath, expectedHash)
+  const targetCommand = await driver.wait(
+    until.elementLocated(By.css(targetSelector)),
+    NAVIGATION_TIMEOUT_MS,
+  )
+  await targetCommand.click()
   await driver.wait(async () => {
     const panels = await driver.findElements(By.css('.command-palette-panel'))
     return panels.length === 0

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -828,10 +828,33 @@ async function runPaletteNavigation(driver, options) {
 }
 
 async function clickSidebarLink(driver, href) {
-  const link = await driver.wait(
-    until.elementLocated(By.css(`.app-sidebar .app-nav-link[href="${href}"]`)),
-    NAVIGATION_TIMEOUT_MS,
-  )
+  const selector = `.app-sidebar .app-nav-link[href="${href}"]`
+
+  const findVisibleLink = async () => {
+    const links = await driver.findElements(By.css(selector))
+    for (const link of links) {
+      if (await link.isDisplayed()) {
+        return link
+      }
+    }
+    return null
+  }
+
+  let link = await findVisibleLink()
+  if (!link) {
+    const menuButton = await driver.wait(
+      until.elementLocated(By.css('.app-topbar > div > button.app-icon-button')),
+      NAVIGATION_TIMEOUT_MS,
+    )
+    await menuButton.click()
+    await driver.wait(async () => (await findVisibleLink()) !== null, NAVIGATION_TIMEOUT_MS)
+    link = await findVisibleLink()
+  }
+
+  if (!link) {
+    throw new Error(`Unable to find a visible sidebar link for ${href}`)
+  }
+
   await link.click()
 }
 

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -785,7 +785,7 @@ async function waitForAnchorInView(driver, anchorId) {
 
       const rect = target.getBoundingClientRect()
       const viewportHeight = window.innerHeight || document.documentElement.clientHeight
-      return rect.top >= -24 && rect.top <= viewportHeight * 0.6
+      return rect.bottom >= 0 && rect.top <= viewportHeight
     }, anchorId)
     return result === true
   }, NAVIGATION_TIMEOUT_MS)
@@ -822,7 +822,11 @@ async function runPaletteNavigation(driver, options) {
   assert.match(titleText, expectedTitle)
 
   if (expectedAnchorId) {
-    await driver.wait(until.elementLocated(By.id(expectedAnchorId)), NAVIGATION_TIMEOUT_MS)
+    const anchor = await driver.wait(
+      until.elementLocated(By.id(expectedAnchorId)),
+      NAVIGATION_TIMEOUT_MS,
+    )
+    await scrollElementIntoView(driver, anchor)
     await waitForAnchorInView(driver, expectedAnchorId)
   }
 }

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -665,8 +665,12 @@ async function runWebdriverSmoke(binaryPath) {
 
 async function openCommandPalette(driver) {
   await driver.findElement(By.css('.app-command-trigger')).click()
-  await driver.wait(until.elementLocated(By.css('.command-palette-panel')), NAVIGATION_TIMEOUT_MS)
-  return driver.findElement(By.css('.command-palette-input'))
+  const panel = await driver.wait(
+    until.elementLocated(By.css('.command-palette-panel')),
+    NAVIGATION_TIMEOUT_MS,
+  )
+  const input = await panel.findElement(By.css('.command-palette-input'))
+  return { panel, input }
 }
 
 async function waitForLocation(driver, expectedPath, expectedHash) {
@@ -684,6 +688,10 @@ async function readTopbarTitle(driver) {
     until.elementLocated(By.css('.app-topbar-title')),
     NAVIGATION_TIMEOUT_MS,
   )
+  await driver.wait(async () => {
+    const text = await title.getText()
+    return text.trim().length > 0
+  }, NAVIGATION_TIMEOUT_MS)
   return title.getText()
 }
 
@@ -717,9 +725,16 @@ async function runPaletteNavigation(driver, options) {
     expectedAnchorId,
   } = options
 
-  const input = await openCommandPalette(driver)
+  const { panel, input } = await openCommandPalette(driver)
   await input.clear()
   await input.sendKeys(query, Key.ENTER)
+  await driver.wait(async () => {
+    const panels = await driver.findElements(By.css('.command-palette-panel'))
+    return panels.length === 0
+  }, NAVIGATION_TIMEOUT_MS).catch(async () => {
+    await input.sendKeys(Key.ESCAPE)
+    await driver.wait(until.stalenessOf(panel), NAVIGATION_TIMEOUT_MS)
+  })
   await waitForLocation(driver, expectedPath, expectedHash)
 
   const titleText = await readTopbarTitle(driver)

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -785,44 +785,62 @@ async function runPaletteNavigation(driver, options) {
     expectedAnchorId,
   } = options
 
-  const { panel, input } = await openCommandPalette(driver)
-  await input.clear()
-  await input.sendKeys(query)
-  const targetSelector = getPaletteTargetSelector(expectedPath, expectedHash)
-  const targetCommand = await driver.wait(
-    until.elementLocated(By.css(targetSelector)),
-    NAVIGATION_TIMEOUT_MS,
-  )
-  await targetCommand.click()
-  await driver.wait(async () => {
-    const panels = await driver.findElements(By.css('.command-palette-panel'))
-    if (panels.length === 0) {
-      return true
-    }
-    const location = await readLocation(driver)
-    return location.pathname === expectedPath && (expectedHash == null || location.hash === expectedHash)
-  }, NAVIGATION_TIMEOUT_MS)
+  let stage = 'opening command palette'
 
-  const remainingPanels = await driver.findElements(By.css('.command-palette-panel'))
-  if (remainingPanels.length > 0) {
-    await input.sendKeys(Key.ESCAPE).catch(() => {})
-    await driver.wait(async () => {
-      const panels = await driver.findElements(By.css('.command-palette-panel'))
-      return panels.length === 0
-    }, 3_000).catch(() => {})
-  }
+  try {
+    const { panel, input } = await openCommandPalette(driver)
+    stage = 'typing palette query'
+    await input.clear()
+    await input.sendKeys(query)
 
-  await waitForLocation(driver, expectedPath, expectedHash)
-
-  const titleText = await readTopbarTitle(driver)
-  assert.match(titleText, expectedTitle)
-
-  if (expectedAnchorId) {
-    const anchor = await driver.wait(
-      until.elementLocated(By.id(expectedAnchorId)),
+    const targetSelector = getPaletteTargetSelector(expectedPath, expectedHash)
+    stage = `locating palette command ${targetSelector}`
+    const targetCommand = await driver.wait(
+      until.elementLocated(By.css(targetSelector)),
       NAVIGATION_TIMEOUT_MS,
     )
-    await scrollElementIntoView(driver, anchor)
+
+    stage = 'clicking palette command'
+    await targetCommand.click()
+
+    stage = 'waiting for palette dismissal or navigation'
+    await driver.wait(async () => {
+      const panels = await driver.findElements(By.css('.command-palette-panel'))
+      if (panels.length === 0) {
+        return true
+      }
+      const location = await readLocation(driver)
+      return location.pathname === expectedPath && (expectedHash == null || location.hash === expectedHash)
+    }, NAVIGATION_TIMEOUT_MS)
+
+    stage = 'closing remaining palette panel'
+    const remainingPanels = await driver.findElements(By.css('.command-palette-panel'))
+    if (remainingPanels.length > 0) {
+      await input.sendKeys(Key.ESCAPE).catch(() => {})
+      await driver.wait(async () => {
+        const panels = await driver.findElements(By.css('.command-palette-panel'))
+        return panels.length === 0
+      }, 3_000).catch(() => {})
+    }
+
+    stage = 'waiting for expected location'
+    await waitForLocation(driver, expectedPath, expectedHash)
+
+    stage = 'reading topbar title'
+    const titleText = await readTopbarTitle(driver)
+    assert.match(titleText, expectedTitle)
+
+    if (expectedAnchorId) {
+      stage = `locating anchor #${expectedAnchorId}`
+      const anchor = await driver.wait(
+        until.elementLocated(By.id(expectedAnchorId)),
+        NAVIGATION_TIMEOUT_MS,
+      )
+      await scrollElementIntoView(driver, anchor)
+    }
+  } catch (error) {
+    const details = error instanceof Error ? error.message : String(error)
+    throw new Error(`Palette navigation failed at ${stage}: ${details}`)
   }
 }
 

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -4,7 +4,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { spawn } from 'node:child_process'
-import { access } from 'node:fs/promises'
+import { access, mkdir, writeFile } from 'node:fs/promises'
 import { constants } from 'node:fs'
 import { Builder, By, Capabilities, Key, until } from 'selenium-webdriver'
 
@@ -17,6 +17,9 @@ const APP_READY_TIMEOUT_MS = 45_000
 const MAC_LAUNCH_SMOKE_MS = 5_000
 const CLEANUP_TIMEOUT_MS = 10_000
 const NAVIGATION_TIMEOUT_MS = 15_000
+const ARTIFACT_DIR = process.env.CLAWMASTER_DESKTOP_ARTIFACT_DIR
+  ? path.resolve(process.env.CLAWMASTER_DESKTOP_ARTIFACT_DIR)
+  : path.join(os.tmpdir(), 'clawmaster-desktop-artifacts')
 
 function resolveCommand(name) {
   return process.platform === 'win32' ? `${name}.cmd` : name
@@ -34,6 +37,11 @@ async function pathExists(targetPath) {
   } catch {
     return false
   }
+}
+
+async function ensureArtifactDir() {
+  await mkdir(ARTIFACT_DIR, { recursive: true })
+  return ARTIFACT_DIR
 }
 
 function runCommand(command, args, options = {}) {
@@ -200,7 +208,20 @@ async function runLaunchSmoke(binaryPath) {
       stdout: stdout.join(''),
       stderr: stderr.join(''),
     }
+  } catch (error) {
+    await persistTextArtifacts('desktop-launch-failure', {
+      mode: 'launch',
+      error: error instanceof Error ? error.message : String(error),
+      stdout: stdout.join(''),
+      stderr: stderr.join(''),
+    })
+    throw error
   } finally {
+    await persistTextArtifacts('desktop-launch-smoke', {
+      mode: 'launch',
+      stdout: stdout.join(''),
+      stderr: stderr.join(''),
+    })
     await terminateChild(child)
   }
 }
@@ -279,6 +300,8 @@ async function runWebdriverSmoke(binaryPath) {
         expectedTitle: /(Settings|设置|設定)/,
         expectedAnchorId: 'settings-profile',
       })
+      await verifyDesktopSettingsSurface(driver)
+      await verifyDangerZoneConfirmation(driver)
       await runPaletteNavigation(driver, {
         query: 'verify',
         expectedPath: '/capabilities',
@@ -292,10 +315,15 @@ async function runWebdriverSmoke(binaryPath) {
 
       const titleText = await readTopbarTitle(driver)
       assert.match(titleText, /(Gateway|网关|ゲートウェイ)/)
+      await captureDriverArtifacts(driver, 'desktop-shell-validated', {
+        mode: 'webdriver',
+        page: 'gateway',
+        title: titleText,
+      })
 
       return {
         mode: 'webdriver',
-        details: `validated desktop shell navigation via palette + sidebar (${titleText})`,
+        details: `validated desktop shell navigation, desktop settings, and danger gating (${titleText})`,
         logs: tauriDriver.getLogs(),
       }
     }
@@ -305,12 +333,25 @@ async function runWebdriverSmoke(binaryPath) {
       startupCopy,
       /(ClawMaster|OpenClaw|检测|Detect|Install|安装|Take over|接管)/,
     )
+    await captureDriverArtifacts(driver, 'desktop-startup-shell', {
+      mode: 'webdriver',
+      page: 'startup',
+    })
 
     return {
       mode: 'webdriver',
       details: 'reached desktop startup shell on a clean runtime',
       logs: tauriDriver.getLogs(),
     }
+  } catch (error) {
+    if (driver) {
+      await captureDriverArtifacts(driver, 'desktop-smoke-failure', {
+        mode: 'webdriver',
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+    await persistDriverLogs(tauriDriver.getLogs(), 'desktop-smoke-failure')
+    throw error
   } finally {
     if (driver) {
       await settleWithin(driver.quit(), CLEANUP_TIMEOUT_MS)
@@ -341,6 +382,13 @@ async function readTopbarTitle(driver) {
     NAVIGATION_TIMEOUT_MS,
   )
   return title.getText()
+}
+
+async function scrollElementIntoView(driver, element) {
+  await driver.executeScript(
+    'arguments[0].scrollIntoView({ behavior: "auto", block: "center" })',
+    element,
+  )
 }
 
 async function waitForAnchorInView(driver, anchorId) {
@@ -386,6 +434,82 @@ async function clickSidebarLink(driver, href) {
     NAVIGATION_TIMEOUT_MS,
   )
   await link.click()
+}
+
+async function verifyDesktopSettingsSurface(driver) {
+  const localDataSection = await driver.wait(
+    until.elementLocated(By.id('settings-local-data')),
+    NAVIGATION_TIMEOUT_MS,
+  )
+  await scrollElementIntoView(driver, localDataSection)
+
+  const rebuildButton = await localDataSection.findElement(By.css('.button-secondary'))
+  const resetButton = await localDataSection.findElement(By.css('.button-danger'))
+  assert.equal(await rebuildButton.isEnabled(), false, 'desktop rebuild button should be disabled')
+  assert.equal(await resetButton.isEnabled(), false, 'desktop reset button should be disabled')
+
+  const sectionText = await localDataSection.getText()
+  assert.match(sectionText, /(Node|worker|桌面|desktop|デスクトップ)/)
+}
+
+async function verifyDangerZoneConfirmation(driver) {
+  const dangerSection = await driver.wait(
+    until.elementLocated(By.xpath("//section[contains(@class,'border-red-500/50')]")),
+    NAVIGATION_TIMEOUT_MS,
+  )
+  await scrollElementIntoView(driver, dangerSection)
+
+  const uninstallButton = await dangerSection.findElement(By.css('.button-danger'))
+  await uninstallButton.click()
+
+  const dialog = await driver.wait(
+    until.elementLocated(By.css('[role="dialog"][aria-modal="true"]')),
+    NAVIGATION_TIMEOUT_MS,
+  )
+  const dialogTitle = await dialog.findElement(By.css('#confirm-dialog-title')).getText()
+  assert.ok(dialogTitle.trim().length > 0, 'danger confirmation should render a title')
+
+  const cancelButton = await dialog.findElement(By.css('.button-secondary'))
+  await cancelButton.click()
+  await driver.wait(until.stalenessOf(dialog), NAVIGATION_TIMEOUT_MS)
+}
+
+async function captureDriverArtifacts(driver, name, metadata = {}) {
+  const artifactDir = await ensureArtifactDir()
+  const screenshot = await driver.takeScreenshot()
+  await writeFile(path.join(artifactDir, `${name}.png`), screenshot, 'base64')
+  await writeFile(
+    path.join(artifactDir, `${name}.json`),
+    JSON.stringify({
+      ...metadata,
+      capturedAt: new Date().toISOString(),
+    }, null, 2),
+    'utf8',
+  )
+}
+
+async function persistDriverLogs(logs, name) {
+  await persistTextArtifacts(`${name}-driver-logs`, {
+    stdout: logs.stdout ?? '',
+    stderr: logs.stderr ?? '',
+  })
+}
+
+async function persistTextArtifacts(name, payload) {
+  const artifactDir = await ensureArtifactDir()
+  await writeFile(
+    path.join(artifactDir, `${name}.log`),
+    [`[stdout]`, payload.stdout ?? '', '', `[stderr]`, payload.stderr ?? ''].join('\n'),
+    'utf8',
+  )
+  await writeFile(
+    path.join(artifactDir, `${name}.json`),
+    JSON.stringify({
+      ...payload,
+      capturedAt: new Date().toISOString(),
+    }, null, 2),
+    'utf8',
+  )
 }
 
 export async function runDesktopSmoke() {

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -76,7 +76,10 @@ async function ensureArtifactDir() {
 
 async function seedDesktopSmokeProfile() {
   if (process.env.CLAWMASTER_DESKTOP_SEED_PROFILE !== '1') {
-    return async () => {}
+    return {
+      restore: async () => {},
+      info: null,
+    }
   }
 
   const configDir = path.join(os.homedir(), '.openclaw')
@@ -88,13 +91,23 @@ async function seedDesktopSmokeProfile() {
   await writeFile(`${configPath}.desktop-smoke-backup`, existingConfig ?? '', 'utf8')
   await writeFile(`${configPath}`, `${JSON.stringify(SEEDED_OPENCLAW_CONFIG, null, 2)}\n`, 'utf8')
 
-  return async () => {
-    if (hadExistingConfig && existingConfig !== null) {
-      await writeFile(configPath, existingConfig, 'utf8')
-    } else {
-      await rm(configPath, { force: true })
-    }
-    await rm(`${configPath}.desktop-smoke-backup`, { force: true })
+  return {
+    info: {
+      enabled: true,
+      homeDir: os.homedir(),
+      configDir,
+      configPath,
+      hadExistingConfig,
+      seededConfigPreview: JSON.stringify(SEEDED_OPENCLAW_CONFIG).slice(0, 500),
+    },
+    restore: async () => {
+      if (hadExistingConfig && existingConfig !== null) {
+        await writeFile(configPath, existingConfig, 'utf8')
+      } else {
+        await rm(configPath, { force: true })
+      }
+      await rm(`${configPath}.desktop-smoke-backup`, { force: true })
+    },
   }
 }
 
@@ -603,7 +616,8 @@ async function persistTextArtifacts(name, payload) {
 }
 
 export async function runDesktopSmoke() {
-  const restoreSeedProfile = await seedDesktopSmokeProfile()
+  const seededProfile = await seedDesktopSmokeProfile()
+  await persistTextArtifacts('desktop-smoke-bootstrap', await collectBootstrapDiagnostics(seededProfile.info))
   const binaryPath = await ensureDesktopBinary()
   const mode = getSmokeMode()
 
@@ -614,6 +628,54 @@ export async function runDesktopSmoke() {
 
     return runWebdriverSmoke(binaryPath)
   } finally {
-    await restoreSeedProfile()
+    await seededProfile.restore()
+  }
+}
+
+async function collectBootstrapDiagnostics(seedInfo) {
+  const configPath = seedInfo?.configPath ?? path.join(os.homedir(), '.openclaw', 'openclaw.json')
+  const configExists = await pathExists(configPath)
+  const configContent = configExists ? await readFile(configPath, 'utf8') : ''
+
+  let openclawVersion = ''
+  try {
+    const output = await new Promise((resolve, reject) => {
+      const child = spawn('openclaw', ['--version'], {
+        cwd: repoRoot,
+        env: process.env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+      let stdout = ''
+      let stderr = ''
+      child.stdout?.on('data', (chunk) => {
+        stdout += String(chunk)
+      })
+      child.stderr?.on('data', (chunk) => {
+        stderr += String(chunk)
+      })
+      child.on('error', reject)
+      child.on('exit', (code) => {
+        if (code === 0) {
+          resolve(stdout.trim())
+          return
+        }
+        reject(new Error(stderr.trim() || `openclaw exited with code ${code}`))
+      })
+    })
+    openclawVersion = String(output)
+  } catch (error) {
+    openclawVersion = `ERROR: ${String(error)}`
+  }
+
+  return {
+    seedInfo,
+    env: {
+      home: os.homedir(),
+      path: process.env.PATH ?? '',
+    },
+    configExists,
+    configPath,
+    configPreview: configContent.slice(0, 2000),
+    openclawVersion,
   }
 }

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -796,11 +796,22 @@ async function runPaletteNavigation(driver, options) {
   await targetCommand.click()
   await driver.wait(async () => {
     const panels = await driver.findElements(By.css('.command-palette-panel'))
-    return panels.length === 0
-  }, NAVIGATION_TIMEOUT_MS).catch(async () => {
-    await input.sendKeys(Key.ESCAPE)
-    await driver.wait(until.stalenessOf(panel), NAVIGATION_TIMEOUT_MS)
-  })
+    if (panels.length === 0) {
+      return true
+    }
+    const location = await readLocation(driver)
+    return location.pathname === expectedPath && (expectedHash == null || location.hash === expectedHash)
+  }, NAVIGATION_TIMEOUT_MS)
+
+  const remainingPanels = await driver.findElements(By.css('.command-palette-panel'))
+  if (remainingPanels.length > 0) {
+    await input.sendKeys(Key.ESCAPE).catch(() => {})
+    await driver.wait(async () => {
+      const panels = await driver.findElements(By.css('.command-palette-panel'))
+      return panels.length === 0
+    }, 3_000).catch(() => {})
+  }
+
   await waitForLocation(driver, expectedPath, expectedHash)
 
   const titleText = await readTopbarTitle(driver)

--- a/tests/desktop/smoke.test.mjs
+++ b/tests/desktop/smoke.test.mjs
@@ -1,0 +1,9 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { runDesktopSmoke } from './harness.mjs'
+
+test('desktop shell smoke', { timeout: 15 * 60_000 }, async () => {
+  const result = await runDesktopSmoke()
+  assert.ok(result.details)
+  console.log(`[desktop-smoke] mode=${result.mode} ${result.details}`)
+})

--- a/tests/ui/18-dashboard-module.yaml
+++ b/tests/ui/18-dashboard-module.yaml
@@ -26,7 +26,25 @@ cases:
       - 3 列网格：Node.js、npm、OpenClaw
       - 已安装的显示绿色版本号
       - 未安装的显示红色"未安装"
+      - OpenClaw 卡片中的版本、配置路径与当前实际 host profile 一致，而不是回退到空状态
       - 无 JS 错误（无"Cannot read""undefined"文字）
+
+  - id: dash-01b
+    name: 已完成 profile 不应误回到安装向导
+    preconditions:
+      - 当前 profile 已存在 openclaw.json，且至少配置了一个 provider 与默认模型
+    steps:
+      - action: navigate
+        url: "{BASE_URL}/"
+      - action: wait
+        duration: 2500ms
+      - action: screenshot
+        name: dashboard-ready-profile
+    assertions:
+      - 应直接进入主界面 Layout，而不是显示安装向导
+      - 页面不应出现"核心引擎未安装""安装核心引擎""进入管理大师"这类 setup copy
+      - 概览页的 OpenClaw 卡片显示真实版本号与配置路径
+      - 若当前 shell 执行 `openclaw --version` 成功，页面不得把 OpenClaw 标为未安装
 
   - id: dash-02
     name: 网关状态卡片

--- a/tests/ui/19-cross-module-workflows.yaml
+++ b/tests/ui/19-cross-module-workflows.yaml
@@ -2,6 +2,7 @@ suite: cross-module-workflows
 name: 跨模块主流程
 description: |
   验证跨模块的真实使用路径，而不是单页静态渲染：
+  0. 已完成 profile 在桌面壳内直接进入主界面，不误回退到 setup
   1. onboarding → 模型 → 网关 → OpenClaw WebUI 首次对话
   2. 通道配置 → 上下文日志排障
   3. 技能 / 插件 / MCP 在 ClawMaster 中变更后，于 OpenClaw WebUI 生效
@@ -14,6 +15,25 @@ preconditions:
 viewport: { width: 1440, height: 960 }
 
 cases:
+  - id: flow-00
+    name: 已完成 profile 在桌面壳内直接进入主界面
+    preconditions:
+      - 当前 host 上 `openclaw --version` 可正常返回
+      - 当前 profile 已存在 openclaw.json，且至少配置了一个 provider 与默认模型
+      - 若验证桌面版，必须从原生 Tauri 壳启动而非纯浏览器 URL
+    steps:
+      - action: navigate
+        url: "{BASE_URL}"
+      - action: wait
+        duration: 2000ms
+      - action: screenshot
+        name: flow-desktop-ready-shell
+    assertions:
+      - 应直接进入主界面或概览页，而不是安装向导
+      - 页面中显示的 OpenClaw 版本与 host `openclaw --version` 一致
+      - 页面中显示的 config path 指向当前 profile，而非空路径或默认错误路径
+      - 不允许出现"未安装"与实际 host 状态矛盾的 setup 卡片
+
   - id: flow-01
     name: Onboarding 到模型配置完成首个可用 provider
     preconditions:

--- a/tests/ui/DESKTOP_E2E_ROLLOUT.md
+++ b/tests/ui/DESKTOP_E2E_ROLLOUT.md
@@ -16,6 +16,7 @@ Current slice status:
 - desktop smoke artifacts are uploaded in CI for screenshots/logs
 - CI seeds a temporary minimal OpenClaw profile so Linux/Windows can reach the main app shell
 - CI installs the `openclaw` CLI before desktop smoke
+- the harness can self-bootstrap an `openclaw` shim and records runtime diagnostics when startup falls back to setup
 
 ## Principles
 

--- a/tests/ui/DESKTOP_E2E_ROLLOUT.md
+++ b/tests/ui/DESKTOP_E2E_ROLLOUT.md
@@ -6,6 +6,12 @@ Tracking issue: [#29](https://github.com/clawmaster-ai/clawmaster/issues/29)
 
 Add native desktop end-to-end coverage for ClawMaster so Linux and Windows Tauri builds are exercised in CI with real app launch, shell wiring, and high-value smoke flows.
 
+Current slice status:
+
+- slice 1 harness is implemented under [tests/desktop/README.md](/Users/haili/workspaces/clawmaster/tests/desktop/README.md)
+- macOS contributors can run a local Tauri build-and-launch smoke via `npm run test:desktop`
+- Linux and Windows CI use native WebDriver smoke
+
 ## Principles
 
 - Keep browser-mode `dev-browser` YAML verification as the release-day exploratory path.

--- a/tests/ui/DESKTOP_E2E_ROLLOUT.md
+++ b/tests/ui/DESKTOP_E2E_ROLLOUT.md
@@ -13,6 +13,7 @@ Current slice status:
 - Linux and Windows CI use native WebDriver smoke
 - macOS CI uses launch smoke only
 - Linux and Windows native smoke now covers command palette page jump, section deep-link, and sidebar navigation
+- desktop smoke artifacts are uploaded in CI for screenshots/logs
 
 ## Principles
 
@@ -44,6 +45,13 @@ Status:
 - verify Settings renders desktop diagnostics and runtime/local-data state
 - verify one destructive flow remains gated by confirmation
 - harden CI retries/timeouts and capture screenshots on failure
+
+Status:
+
+- partially implemented in `tests/desktop/harness.mjs` and `.github/workflows/desktop-e2e.yml`
+- Settings desktop Local Data read-only state is asserted
+- Danger Zone confirmation dialog is asserted
+- CI now uploads desktop smoke screenshots/logs as artifacts
 
 ## Suggested test matrix
 

--- a/tests/ui/DESKTOP_E2E_ROLLOUT.md
+++ b/tests/ui/DESKTOP_E2E_ROLLOUT.md
@@ -1,0 +1,48 @@
+# Desktop E2E Rollout
+
+Tracking issue: [#29](https://github.com/clawmaster-ai/clawmaster/issues/29)
+
+## Goal
+
+Add native desktop end-to-end coverage for ClawMaster so Linux and Windows Tauri builds are exercised in CI with real app launch, shell wiring, and high-value smoke flows.
+
+## Principles
+
+- Keep browser-mode `dev-browser` YAML verification as the release-day exploratory path.
+- Add a small native desktop smoke suite first, then grow coverage only where desktop-specific regressions are likely.
+- Prefer stable user journeys over exhaustive click coverage.
+- Treat macOS native desktop E2E as a later follow-up.
+
+## Planned slices
+
+### Slice 1: Harness
+
+- add a `tauri-driver`-based launch path for native desktop tests
+- document local prerequisites and how to run the suite
+- prove app boot and shell hydration on Linux and Windows
+
+### Slice 2: Core navigation
+
+- verify sidebar navigation across a few representative modules
+- verify command palette open, search, and route jump
+- verify one hash-section jump on an async page
+
+### Slice 3: Desktop-only confidence
+
+- verify Settings renders desktop diagnostics and runtime/local-data state
+- verify one destructive flow remains gated by confirmation
+- harden CI retries/timeouts and capture screenshots on failure
+
+## Suggested test matrix
+
+| Platform | Coverage |
+| --- | --- |
+| Linux x64 | required |
+| Windows x64 | required |
+| macOS | deferred |
+
+## Exit criteria
+
+- Linux and Windows native desktop smoke tests run in CI
+- failures produce enough logs/screenshots to debug quickly
+- contributor docs explain when to use native desktop E2E vs `dev-browser`

--- a/tests/ui/DESKTOP_E2E_ROLLOUT.md
+++ b/tests/ui/DESKTOP_E2E_ROLLOUT.md
@@ -15,6 +15,7 @@ Current slice status:
 - Linux and Windows native smoke now covers command palette page jump, section deep-link, and sidebar navigation
 - desktop smoke artifacts are uploaded in CI for screenshots/logs
 - CI seeds a temporary minimal OpenClaw profile so Linux/Windows can reach the main app shell
+- CI installs the `openclaw` CLI before desktop smoke
 
 ## Principles
 

--- a/tests/ui/DESKTOP_E2E_ROLLOUT.md
+++ b/tests/ui/DESKTOP_E2E_ROLLOUT.md
@@ -14,6 +14,7 @@ Current slice status:
 - macOS CI uses launch smoke only
 - Linux and Windows native smoke now covers command palette page jump, section deep-link, and sidebar navigation
 - desktop smoke artifacts are uploaded in CI for screenshots/logs
+- CI seeds a temporary minimal OpenClaw profile so Linux/Windows can reach the main app shell
 
 ## Principles
 

--- a/tests/ui/DESKTOP_E2E_ROLLOUT.md
+++ b/tests/ui/DESKTOP_E2E_ROLLOUT.md
@@ -12,6 +12,7 @@ Current slice status:
 - macOS contributors can run a local Tauri build-and-launch smoke via `npm run test:desktop`
 - Linux and Windows CI use native WebDriver smoke
 - macOS CI uses launch smoke only
+- Linux and Windows native smoke now covers command palette page jump, section deep-link, and sidebar navigation
 
 ## Principles
 
@@ -33,6 +34,10 @@ Current slice status:
 - verify sidebar navigation across a few representative modules
 - verify command palette open, search, and route jump
 - verify one hash-section jump on an async page
+
+Status:
+
+- implemented in `tests/desktop/harness.mjs` for Linux and Windows WebDriver smoke
 
 ### Slice 3: Desktop-only confidence
 

--- a/tests/ui/DESKTOP_E2E_ROLLOUT.md
+++ b/tests/ui/DESKTOP_E2E_ROLLOUT.md
@@ -4,20 +4,21 @@ Tracking issue: [#29](https://github.com/clawmaster-ai/clawmaster/issues/29)
 
 ## Goal
 
-Add native desktop end-to-end coverage for ClawMaster so Linux and Windows Tauri builds are exercised in CI with real app launch, shell wiring, and high-value smoke flows.
+Add native desktop end-to-end coverage for ClawMaster so Linux and Windows Tauri builds are exercised in CI with real app launch, shell wiring, and high-value smoke flows, while macOS gets a real build-and-launch smoke lane.
 
 Current slice status:
 
 - slice 1 harness is implemented under [tests/desktop/README.md](/Users/haili/workspaces/clawmaster/tests/desktop/README.md)
 - macOS contributors can run a local Tauri build-and-launch smoke via `npm run test:desktop`
 - Linux and Windows CI use native WebDriver smoke
+- macOS CI uses launch smoke only
 
 ## Principles
 
 - Keep browser-mode `dev-browser` YAML verification as the release-day exploratory path.
 - Add a small native desktop smoke suite first, then grow coverage only where desktop-specific regressions are likely.
 - Prefer stable user journeys over exhaustive click coverage.
-- Treat macOS native desktop E2E as a later follow-up.
+- Treat macOS native WebDriver coverage as a later follow-up.
 
 ## Planned slices
 
@@ -45,10 +46,11 @@ Current slice status:
 | --- | --- |
 | Linux x64 | required |
 | Windows x64 | required |
-| macOS | deferred |
+| macOS | required launch smoke |
 
 ## Exit criteria
 
 - Linux and Windows native desktop smoke tests run in CI
+- macOS build-and-launch smoke runs in CI
 - failures produce enough logs/screenshots to debug quickly
 - contributor docs explain when to use native desktop E2E vs `dev-browser`

--- a/tests/ui/README.md
+++ b/tests/ui/README.md
@@ -78,6 +78,7 @@ cases:
 - 日常 UI 改动继续优先使用 `dev-browser` + YAML 描述流做快速验证
 - Linux / Windows 的 Tauri 原生冒烟覆盖单独建设，不与浏览器描述流混用
 - 在原生 E2E 落地前，发布验证仍以 `19-cross-module-workflows.yaml` 为主
+- 本地 macOS 开发机可先运行 `npm run test:desktop`，执行真实 Tauri 构建 + 启动冒烟
 
 ## dev-browser Quick Verification (Recommended)
 

--- a/tests/ui/README.md
+++ b/tests/ui/README.md
@@ -70,6 +70,15 @@ cases:
 | Cypress | E2E 测试 |
 | 手动 | 截图对照检查 |
 
+## Native Desktop E2E Track
+
+桌面原生 E2E 单独跟踪于 [#29](https://github.com/clawmaster-ai/clawmaster/issues/29)，规划文档见 [DESKTOP_E2E_ROLLOUT.md](/Users/haili/workspaces/clawmaster/tests/ui/DESKTOP_E2E_ROLLOUT.md)。
+
+当前建议：
+- 日常 UI 改动继续优先使用 `dev-browser` + YAML 描述流做快速验证
+- Linux / Windows 的 Tauri 原生冒烟覆盖单独建设，不与浏览器描述流混用
+- 在原生 E2E 落地前，发布验证仍以 `19-cross-module-workflows.yaml` 为主
+
 ## dev-browser Quick Verification (Recommended)
 
 During development, use headless Playwright via `dev-browser` for rapid visual + functional checks:

--- a/tests/ui/README.md
+++ b/tests/ui/README.md
@@ -109,6 +109,11 @@ page.screenshot({ path: '/tmp/observe-refreshed.png' })
 - No 500 errors in browser console (`page.evaluate(() => performance.getEntriesByType('resource').filter(r => r.name.includes('api') && r.responseStatus >= 500))`)
 - Responsive check: `page.setViewportSize({ width: 375, height: 812 })` + screenshot
 
+**Extra checks for runtime-sensitive flows:**
+- If the profile is already configured, verify the app lands in the main shell rather than setup/onboarding.
+- Compare the UI-reported OpenClaw version and config path against the real host output of `openclaw --version` and the active profile path.
+- For desktop verification, treat any native shell that silently falls back to browser `/api` behavior as a regression even if the page still renders.
+
 **When to run:**
 - After any UI component change
 - After i18n key additions/modifications


### PR DESCRIPTION
## Summary
- add native desktop smoke coverage under `tests/desktop/`
- add Linux and Windows desktop smoke CI via `tauri-driver`
- add a macOS-safe local desktop smoke path with `npm run test:desktop`
- fix desktop runtime detection for Tauri v2 so the app stops falling back to browser-mode `/api` behavior
- tighten descriptive `tests/ui` flows around runtime-sensitive checks

## What Changed
### Desktop smoke harness
- add `tests/desktop/harness.mjs`
- add `tests/desktop/smoke.test.mjs`
- add `tests/desktop/README.md`
- add `.github/workflows/desktop-e2e.yml`
- add `npm run test:desktop`

### Desktop runtime fix
- detect Tauri desktop via `__TAURI_INTERNALS__` as well as legacy `__TAURI__`
- update the legacy startup detector to use the shared desktop gate
- avoid false setup/"OpenClaw not installed" states caused by misclassifying Tauri v2 as web mode

### Setup hardening
- let setup capability detection trust `detectSystem()` for engine/memory/agent readiness before falling back to ad hoc CLI probing
- add regressions for Tauri v2 desktop detection and setup readiness mismatch

### Descriptive UI coverage
- add runtime-sensitive checks to dashboard and cross-module YAML flows
- explicitly require ready profiles to land in the main shell rather than setup
- require OpenClaw version and config path shown in UI to match host reality

## Why
We found a real native desktop regression while proving the first smoke slice on macOS: the app could render inside Tauri while still treating itself as web mode, which led to wrong setup state and wrong install status in the UI. This PR adds the desktop smoke track and fixes that runtime detection bug.

## Verification
### Local macOS
- `npm run test:desktop`
- `npm run test --workspace=@openclaw-manager/web -- src/shared/adapters/__tests__/platform.test.ts src/modules/setup/__tests__/realAdapter.test.ts`

### Visual proof
- real Tauri window before fix: setup/onboarding false-negative state
- real Tauri window after fix: main shell + OpenClaw version/path rendered correctly

### CI
- Linux desktop smoke via `tauri-driver`
- Windows desktop smoke via `tauri-driver`

## Follow-up scope
- expand from harness smoke into deeper desktop workflow coverage
- keep macOS on local launch smoke until native desktop WebDriver support exists upstream

Closes #29