### PR TITLE
fix(ci): harden desktop smoke webdriver bootstrap

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -97,10 +97,28 @@ jobs:
         run: |
           cargo install --git https://github.com/chippers/msedgedriver-tool --locked
           $driverDir = Join-Path $env:RUNNER_TEMP 'msedgedriver'
-          New-Item -ItemType Directory -Force -Path $driverDir | Out-Null
-          Push-Location $driverDir
-          msedgedriver-tool
-          Pop-Location
+          $maxAttempts = 3
+
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $driverDir
+            New-Item -ItemType Directory -Force -Path $driverDir | Out-Null
+            Push-Location $driverDir
+
+            try {
+              msedgedriver-tool
+              break
+            } catch {
+              if ($attempt -eq $maxAttempts) {
+                throw
+              }
+
+              Write-Warning "msedgedriver-tool attempt $attempt/$maxAttempts failed: $($_.Exception.Message)"
+              Start-Sleep -Seconds (5 * $attempt)
+            } finally {
+              Pop-Location
+            }
+          }
+
           $driverDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Run desktop smoke

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
     "prepack": "npm run build:backend && npm run build",
-    "test:cli": "node --test bin/*.test.mjs",
+    "test:cli": "node --test bin/*.test.mjs tests/desktop/harness.unit.test.mjs",
     "test:plugins": "npx tsx --test plugins/memory-clawmaster-powermem/*.test.ts",
     "test:desktop": "node --test tests/desktop/smoke.test.mjs",
     "test": "npm run test:cli && npm run test:plugins && npm run test --workspace=@openclaw-manager/backend && npm run test --workspace=@openclaw-manager/web"

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -17,7 +17,15 @@ const APP_READY_TIMEOUT_MS = 45_000
 const MAC_LAUNCH_SMOKE_MS = 5_000
 const CLEANUP_TIMEOUT_MS = 10_000
 const NAVIGATION_TIMEOUT_MS = 15_000
+const WEBDRIVER_SESSION_RETRY_DELAY_MS = 1_500
+const WEBDRIVER_SESSION_MAX_ATTEMPTS = 3
 const CAPABILITIES_TITLE_PATTERN = /(Capability Center|Assistant Capabilities|能力中心|助手能力|機能センター|アシスタント機能)/
+const RETRYABLE_WEBDRIVER_SESSION_ERROR_PATTERNS = [
+  /\bECONNRESET\b/i,
+  /\bECONNREFUSED\b/i,
+  /socket hang up/i,
+  /Connection refused/i,
+]
 const ARTIFACT_DIR = process.env.CLAWMASTER_DESKTOP_ARTIFACT_DIR
   ? path.resolve(process.env.CLAWMASTER_DESKTOP_ARTIFACT_DIR)
   : path.join(os.tmpdir(), 'clawmaster-desktop-artifacts')
@@ -383,6 +391,61 @@ function waitForPort(port, timeoutMs) {
   })
 }
 
+function sleep(delayMs) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayMs)
+  })
+}
+
+export function isRetryableWebdriverSessionError(error) {
+  const details = error instanceof Error
+    ? [error.message, error.stack].filter(Boolean).join('\n')
+    : String(error)
+  return RETRYABLE_WEBDRIVER_SESSION_ERROR_PATTERNS.some((pattern) => pattern.test(details))
+}
+
+export async function buildWebdriverSessionWithRetry(options) {
+  const {
+    build,
+    reset,
+    onRetry,
+    maxAttempts = WEBDRIVER_SESSION_MAX_ATTEMPTS,
+    retryDelayMs = WEBDRIVER_SESSION_RETRY_DELAY_MS,
+  } = options
+
+  assert.equal(typeof build, 'function', 'buildWebdriverSessionWithRetry requires a build function')
+
+  let attempt = 0
+  let lastError
+
+  while (attempt < maxAttempts) {
+    attempt += 1
+    try {
+      return await build()
+    } catch (error) {
+      lastError = error
+      if (attempt >= maxAttempts || !isRetryableWebdriverSessionError(error)) {
+        throw error
+      }
+
+      await onRetry?.({
+        attempt,
+        maxAttempts,
+        delayMs: retryDelayMs,
+        error,
+      })
+      await reset?.({
+        attempt,
+        maxAttempts,
+        error,
+      })
+      await sleep(retryDelayMs)
+    }
+  }
+
+  throw lastError
+}
+
 async function ensureDesktopBinary() {
   if (process.env.CLAWMASTER_DESKTOP_SKIP_BUILD === '1' && await pathExists(getDesktopBinaryPath())) {
     return getDesktopBinaryPath()
@@ -543,13 +606,36 @@ async function startTauriDriver() {
 }
 
 async function runWebdriverSmoke(binaryPath) {
-  const tauriDriver = await startTauriDriver()
+  const tauriDriverAttempts = []
+  let tauriDriver = await startTauriDriver()
   let driver
   let currentStep = 'starting webdriver session'
 
   const setStep = (step) => {
     currentStep = step
     console.log(`[desktop-smoke] step=${step}`)
+  }
+
+  const flushTauriDriverLogs = (driverHandle = tauriDriver) => {
+    if (!driverHandle) {
+      return
+    }
+    tauriDriverAttempts.push(driverHandle.getLogs())
+  }
+
+  const getCombinedTauriDriverLogs = (includeCurrent = false) => {
+    const entries = includeCurrent && tauriDriver
+      ? [...tauriDriverAttempts, tauriDriver.getLogs()]
+      : tauriDriverAttempts
+
+    return {
+      stdout: entries
+        .map((entry, index) => `--- tauri-driver attempt ${index + 1} stdout ---\n${entry.stdout ?? ''}`)
+        .join('\n'),
+      stderr: entries
+        .map((entry, index) => `--- tauri-driver attempt ${index + 1} stderr ---\n${entry.stderr ?? ''}`)
+        .join('\n'),
+    }
   }
 
   try {
@@ -559,10 +645,28 @@ async function runWebdriverSmoke(binaryPath) {
     capabilities.set('tauri:options', { application: binaryPath })
 
     setStep('connecting webdriver session')
-    driver = await new Builder()
-      .usingServer(`http://127.0.0.1:${TAURI_DRIVER_PORT}`)
-      .withCapabilities(capabilities)
-      .build()
+    driver = await buildWebdriverSessionWithRetry({
+      async build() {
+        return new Builder()
+          .usingServer(`http://127.0.0.1:${TAURI_DRIVER_PORT}`)
+          .withCapabilities(capabilities)
+          .build()
+      },
+      async reset() {
+        const previousTauriDriver = tauriDriver
+        flushTauriDriverLogs(previousTauriDriver)
+        tauriDriver = null
+        await settleWithin(terminateChild(previousTauriDriver.child), CLEANUP_TIMEOUT_MS)
+        tauriDriver = await startTauriDriver()
+      },
+      async onRetry({ attempt, maxAttempts, delayMs, error }) {
+        const details = error instanceof Error ? error.message : String(error)
+        setStep(`retrying webdriver session ${attempt + 1}/${maxAttempts}`)
+        console.warn(
+          `[desktop-smoke] webdriver session attempt ${attempt}/${maxAttempts} failed with retryable bootstrap error: ${details}. Retrying in ${delayMs}ms.`,
+        )
+      },
+    })
 
     setStep('waiting for initial shell')
     await driver.wait(
@@ -619,7 +723,7 @@ async function runWebdriverSmoke(binaryPath) {
       return {
         mode: 'webdriver',
         details: `validated desktop shell navigation, desktop settings, and danger gating (${titleText})`,
-        logs: tauriDriver.getLogs(),
+        logs: getCombinedTauriDriverLogs(true),
       }
     }
 
@@ -675,7 +779,7 @@ async function runWebdriverSmoke(binaryPath) {
       return {
         mode: 'webdriver',
         details: `continued from setup wizard into desktop shell and validated settings gating (${titleText})`,
-        logs: tauriDriver.getLogs(),
+        logs: getCombinedTauriDriverLogs(true),
       }
     }
 
@@ -693,7 +797,7 @@ async function runWebdriverSmoke(binaryPath) {
     return {
       mode: 'webdriver',
       details: 'reached desktop startup shell on a clean runtime',
-      logs: tauriDriver.getLogs(),
+      logs: getCombinedTauriDriverLogs(true),
     }
   } catch (error) {
     if (driver) {
@@ -707,13 +811,15 @@ async function runWebdriverSmoke(binaryPath) {
         diagnostics,
       })
     }
-    await persistDriverLogs(tauriDriver.getLogs(), 'desktop-smoke-failure')
+    await persistDriverLogs(getCombinedTauriDriverLogs(true), 'desktop-smoke-failure')
     throw error
   } finally {
     if (driver) {
       await settleWithin(driver.quit(), CLEANUP_TIMEOUT_MS)
     }
-    await settleWithin(terminateChild(tauriDriver.child), CLEANUP_TIMEOUT_MS)
+    if (tauriDriver) {
+      await settleWithin(terminateChild(tauriDriver.child), CLEANUP_TIMEOUT_MS)
+    }
   }
 }
 

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -397,6 +397,21 @@ function sleep(delayMs) {
   })
 }
 
+function normalizeProcessMatchPath(targetPath) {
+  return process.platform === 'win32'
+    ? path.normalize(targetPath).toLowerCase()
+    : targetPath
+}
+
+function quotePowerShellLiteral(value) {
+  return `'${String(value).replaceAll("'", "''")}'`
+}
+
+export function collectNewProcessIds(previousPids, currentPids) {
+  const knownPids = new Set(previousPids)
+  return currentPids.filter((pid) => !knownPids.has(pid))
+}
+
 export function isRetryableWebdriverSessionError(error) {
   const details = error instanceof Error
     ? [error.message, error.stack].filter(Boolean).join('\n')
@@ -444,6 +459,103 @@ export async function buildWebdriverSessionWithRetry(options) {
   }
 
   throw lastError
+}
+
+async function listDesktopAppProcessIds(binaryPath) {
+  const normalizedBinaryPath = normalizeProcessMatchPath(binaryPath)
+
+  if (process.platform === 'win32') {
+    const output = await readCommandOutput('pwsh', [
+      '-NoLogo',
+      '-NoProfile',
+      '-Command',
+      [
+        `$target = ${quotePowerShellLiteral(normalizedBinaryPath)}`,
+        'Get-CimInstance Win32_Process |',
+        'Where-Object { $_.ExecutablePath -and $_.ExecutablePath.ToLowerInvariant() -eq $target } |',
+        'ForEach-Object { $_.ProcessId }',
+      ].join(' '),
+    ]).catch(() => '')
+
+    return output
+      .split(/\r?\n/)
+      .map((line) => Number.parseInt(line.trim(), 10))
+      .filter((pid) => Number.isInteger(pid) && pid > 0)
+      .sort((left, right) => left - right)
+  }
+
+  const output = await readCommandOutput('ps', ['-ax', '-o', 'pid=', '-o', 'command=']).catch(() => '')
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.match(/^\s*(\d+)\s+(.*)$/))
+    .filter(Boolean)
+    .filter((match) => {
+      const command = match[2].trim()
+      return command === binaryPath || command.startsWith(`${binaryPath} `)
+    })
+    .map((match) => Number.parseInt(match[1], 10))
+    .filter((pid) => Number.isInteger(pid) && pid > 0)
+    .sort((left, right) => left - right)
+}
+
+async function terminateProcessId(pid, options = {}) {
+  const { force = false } = options
+
+  if (process.platform === 'win32') {
+    const args = ['/PID', String(pid), '/T']
+    if (force) {
+      args.push('/F')
+    }
+    await readCommandOutput('taskkill', args).catch((error) => {
+      const details = error instanceof Error ? error.message : String(error)
+      if (!/not found|no running instance|cannot find/i.test(details)) {
+        throw error
+      }
+    })
+    return
+  }
+
+  try {
+    process.kill(pid, force ? 'SIGKILL' : 'SIGTERM')
+  } catch (error) {
+    if (error?.code !== 'ESRCH') {
+      throw error
+    }
+  }
+}
+
+async function cleanupRetriedDesktopAppProcesses(binaryPath, previousPids) {
+  const currentPids = await listDesktopAppProcessIds(binaryPath)
+  const launchedPids = collectNewProcessIds(previousPids, currentPids)
+
+  if (launchedPids.length === 0) {
+    return { terminatedPids: [], survivingPids: [] }
+  }
+
+  for (const pid of launchedPids) {
+    await terminateProcessId(pid)
+  }
+
+  await sleep(500)
+
+  let survivingPids = collectNewProcessIds(previousPids, await listDesktopAppProcessIds(binaryPath))
+  for (const pid of survivingPids) {
+    await terminateProcessId(pid, { force: true })
+  }
+
+  await sleep(500)
+  survivingPids = collectNewProcessIds(previousPids, await listDesktopAppProcessIds(binaryPath))
+
+  if (survivingPids.length > 0) {
+    throw new Error(
+      `Failed to terminate retried desktop app process(es): ${survivingPids.join(', ')}`,
+    )
+  }
+
+  return {
+    terminatedPids: launchedPids,
+    survivingPids,
+  }
 }
 
 async function ensureDesktopBinary() {
@@ -610,6 +722,7 @@ async function runWebdriverSmoke(binaryPath) {
   let tauriDriver = await startTauriDriver()
   let driver
   let currentStep = 'starting webdriver session'
+  let desktopAppPidsBeforeAttempt = []
 
   const setStep = (step) => {
     currentStep = step
@@ -647,12 +760,22 @@ async function runWebdriverSmoke(binaryPath) {
     setStep('connecting webdriver session')
     driver = await buildWebdriverSessionWithRetry({
       async build() {
+        desktopAppPidsBeforeAttempt = await listDesktopAppProcessIds(binaryPath)
         return new Builder()
           .usingServer(`http://127.0.0.1:${TAURI_DRIVER_PORT}`)
           .withCapabilities(capabilities)
           .build()
       },
       async reset() {
+        const appCleanup = await cleanupRetriedDesktopAppProcesses(
+          binaryPath,
+          desktopAppPidsBeforeAttempt,
+        )
+        if (appCleanup.terminatedPids.length > 0) {
+          console.warn(
+            `[desktop-smoke] terminated retried desktop app process(es): ${appCleanup.terminatedPids.join(', ')}`,
+          )
+        }
         const previousTauriDriver = tauriDriver
         flushTauriDriverLogs(previousTauriDriver)
         tauriDriver = null

--- a/tests/desktop/harness.unit.test.mjs
+++ b/tests/desktop/harness.unit.test.mjs
@@ -2,8 +2,15 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import {
   buildWebdriverSessionWithRetry,
+  collectNewProcessIds,
   isRetryableWebdriverSessionError,
 } from './harness.mjs'
+
+test('collectNewProcessIds returns only processes launched after the baseline snapshot', () => {
+  assert.deepEqual(collectNewProcessIds([], []), [])
+  assert.deepEqual(collectNewProcessIds([101, 202], [101, 202, 303, 404]), [303, 404])
+  assert.deepEqual(collectNewProcessIds([101, 202], [202, 101]), [])
+})
 
 test('isRetryableWebdriverSessionError matches transient driver transport failures', () => {
   assert.equal(
@@ -44,6 +51,31 @@ test('buildWebdriverSessionWithRetry retries transient webdriver bootstrap error
   assert.deepEqual(session, { id: 'session-ok' })
   assert.equal(attempts, 3)
   assert.deepEqual(events, ['retry-1', 'reset-1', 'retry-2', 'reset-2'])
+})
+
+test('buildWebdriverSessionWithRetry waits for reset before retrying the next attempt', async () => {
+  const events = []
+  let attempts = 0
+
+  const session = await buildWebdriverSessionWithRetry({
+    retryDelayMs: 0,
+    async build() {
+      attempts += 1
+      events.push(`build-${attempts}`)
+      if (attempts === 1) {
+        throw new Error('ECONNRESET socket hang up')
+      }
+      return { id: 'session-after-reset' }
+    },
+    async reset() {
+      events.push('reset-start')
+      await Promise.resolve()
+      events.push('reset-end')
+    },
+  })
+
+  assert.deepEqual(session, { id: 'session-after-reset' })
+  assert.deepEqual(events, ['build-1', 'reset-start', 'reset-end', 'build-2'])
 })
 
 test('buildWebdriverSessionWithRetry does not retry non-retryable errors', async () => {

--- a/tests/desktop/harness.unit.test.mjs
+++ b/tests/desktop/harness.unit.test.mjs
@@ -1,0 +1,92 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  buildWebdriverSessionWithRetry,
+  isRetryableWebdriverSessionError,
+} from './harness.mjs'
+
+test('isRetryableWebdriverSessionError matches transient driver transport failures', () => {
+  assert.equal(
+    isRetryableWebdriverSessionError(new Error('ECONNRESET socket hang up while creating session')),
+    true,
+  )
+  assert.equal(
+    isRetryableWebdriverSessionError(new Error('Connection refused during webdriver bootstrap')),
+    true,
+  )
+  assert.equal(
+    isRetryableWebdriverSessionError(new Error('expected title to match gateway page')),
+    false,
+  )
+})
+
+test('buildWebdriverSessionWithRetry retries transient webdriver bootstrap errors', async () => {
+  const events = []
+  let attempts = 0
+
+  const session = await buildWebdriverSessionWithRetry({
+    retryDelayMs: 0,
+    async build() {
+      attempts += 1
+      if (attempts < 3) {
+        throw new Error(attempts === 1 ? 'ECONNRESET socket hang up' : 'Connection refused')
+      }
+      return { id: 'session-ok' }
+    },
+    async onRetry({ attempt }) {
+      events.push(`retry-${attempt}`)
+    },
+    async reset({ attempt }) {
+      events.push(`reset-${attempt}`)
+    },
+  })
+
+  assert.deepEqual(session, { id: 'session-ok' })
+  assert.equal(attempts, 3)
+  assert.deepEqual(events, ['retry-1', 'reset-1', 'retry-2', 'reset-2'])
+})
+
+test('buildWebdriverSessionWithRetry does not retry non-retryable errors', async () => {
+  let attempts = 0
+  let resetCalls = 0
+
+  await assert.rejects(
+    buildWebdriverSessionWithRetry({
+      retryDelayMs: 0,
+      async build() {
+        attempts += 1
+        throw new Error('page title mismatch')
+      },
+      async reset() {
+        resetCalls += 1
+      },
+    }),
+    /page title mismatch/,
+  )
+
+  assert.equal(attempts, 1)
+  assert.equal(resetCalls, 0)
+})
+
+test('buildWebdriverSessionWithRetry stops after the configured attempt limit', async () => {
+  let attempts = 0
+  let resetCalls = 0
+
+  await assert.rejects(
+    buildWebdriverSessionWithRetry({
+      maxAttempts: 2,
+      retryDelayMs: 0,
+      async build() {
+        attempts += 1
+        throw new Error('ECONNREFUSED webdriver bootstrap failed')
+      },
+      async reset() {
+        resetCalls += 1
+      },
+    }),
+    /ECONNREFUSED webdriver bootstrap failed/,
+  )
+
+  assert.equal(attempts, 2)
+  assert.equal(resetCalls, 1)
+})


### PR DESCRIPTION
## What
- harden the desktop smoke harness against transient WebDriver session bootstrap failures by retrying retryable transport errors and restarting tauri-driver between attempts
- preserve per-attempt driver logs in failure artifacts so flaky startup failures stay diagnosable
- add focused unit tests for the retry helper and include them in the root CLI test script

## Why
Linux desktop smoke has shown intermittent PR failures where the Tauri app finishes building but WebDriver session creation dies with ECONNRESET or Connection refused. Recent successful runs on main also showed transient driver connection errors before eventual success, so the harness needs bounded retry behavior instead of treating the first transport blip as a product failure.

Closes #37.

## How
- classify retryable bootstrap errors from the Selenium/Tauri transport layer
- wrap session creation in a small retry helper with bounded attempts and delay
- restart tauri-driver between attempts and aggregate logs across attempts
- cover the helper with fast node --test cases and verify with npm test and npm run test:desktop
