### PR TITLE
fix: respect HOME for CLI service state paths

### DIFF
--- a/bin/clawmaster.mjs
+++ b/bin/clawmaster.mjs
@@ -15,8 +15,21 @@ const root = resolve(__dirname, '..')
 const cliEntryPath = fileURLToPath(import.meta.url)
 const require = createRequire(import.meta.url)
 const pkg = require(resolve(root, 'package.json'))
-const serviceStateDir = join(os.homedir(), '.clawmaster', 'service')
-const serviceStateFile = join(serviceStateDir, 'service-state.json')
+
+function getCliHomeDir() {
+  const home = String(process.env.HOME ?? '').trim()
+  return home || os.homedir()
+}
+
+export function resolveServiceStatePaths(homeDir = getCliHomeDir()) {
+  const serviceStateDir = join(homeDir, '.clawmaster', 'service')
+  return {
+    serviceStateDir,
+    serviceStateFile: join(serviceStateDir, 'service-state.json'),
+  }
+}
+
+const { serviceStateDir, serviceStateFile } = resolveServiceStatePaths()
 
 function printHelp() {
   console.log(`

--- a/bin/clawmaster.test.mjs
+++ b/bin/clawmaster.test.mjs
@@ -41,6 +41,15 @@ test('published package ships the backend ESM package marker', () => {
   )
 })
 
+test('resolveServiceStatePaths prefers HOME when provided', () => {
+  const result = cliModule.resolveServiceStatePaths('C:\\temp\\clawmaster-home')
+
+  assert.deepEqual(result, {
+    serviceStateDir: 'C:\\temp\\clawmaster-home\\.clawmaster\\service',
+    serviceStateFile: 'C:\\temp\\clawmaster-home\\.clawmaster\\service\\service-state.json',
+  })
+})
+
 test('resolveServiceUrls maps wildcard hosts to local probe urls', () => {
   assert.deepEqual(cliModule.resolveServiceUrls('0.0.0.0', '3001'), {
     bindHost: '0.0.0.0',


### PR DESCRIPTION
## What

Update the CLI service-state path resolution to respect `HOME` when it is explicitly provided, instead of always anchoring service metadata under `os.homedir()`.

## Why

On Windows, the CLI test coverage already expects `clawmaster status` to reuse the recorded local daemon token/metadata from a temporary home directory. That path currently fails because `os.homedir()` keeps resolving to the user profile even when the process is intentionally sandboxed with `HOME`, so the CLI reads the wrong `service-state.json` location and reports the service as unreachable.

## How

Added a small helper that resolves the service-state directory/file from `HOME` first and falls back to `os.homedir()`. Also added a focused regression test for the resolved service-state paths, alongside the existing status regression test that now passes on Windows.

## Screenshots

Not applicable.

## Related Issue

Closes #64

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] CI / tooling
- [ ] Chore (dependencies, config)

## Testing

- [ ] `npm test` passes locally
- [x] New or modified behavior has unit tests
- [x] No `console.log` or debug artifacts left in code

`node --test bin/*.test.mjs` passes locally.

`npm test` is still blocked by an existing unrelated Windows/WSL path assertion in `plugins/memory-clawmaster-powermem/workspaceImport.test.ts`:
`resolveOpenclawWorkspaceDir prefers WSL HOME when the managed data root is a mounted Windows path`

## Dependency Changes

- [x] No new non-Node.js runtime dependencies introduced
- [x] New npm packages (if any) are justified in the Summary above and have an open issue

## Checklist

- [x] PR is a **draft** if not yet ready for review
- [x] Branch name follows convention (`feat/`, `fix/`, `chore/`, `docs/`, `test/`, `ci/`)
- [x] All new i18n strings added to `packages/web/src/locales/main/{zh,en,ja}.ts`