### PR TITLE
fix(ci): replace flaky Rust setup action

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,69 @@
+name: Setup Rust
+description: Install the stable Rust toolchain with rustup without fetching an extra GitHub action archive
+
+inputs:
+  targets:
+    description: Comma-separated Rust targets to install
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Install stable Rust toolchain (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        INPUT_TARGETS: ${{ inputs.targets }}
+      run: |
+        set -euo pipefail
+
+        if ! command -v rustup >/dev/null 2>&1; then
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs \
+            | sh -s -- --default-toolchain none -y --profile minimal
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.cargo/bin:$PATH"
+        fi
+
+        rustup set profile minimal
+        rustup toolchain install stable --no-self-update
+        rustup default stable
+
+        if [ -n "$INPUT_TARGETS" ]; then
+          for target in ${INPUT_TARGETS//,/ }; do
+            rustup target add "$target" --toolchain stable
+          done
+        fi
+
+        rustc --version --verbose
+        cargo --version
+
+    - name: Install stable Rust toolchain (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        INPUT_TARGETS: ${{ inputs.targets }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+
+        if (-not (Get-Command rustup -ErrorAction SilentlyContinue)) {
+          $installer = Join-Path $env:RUNNER_TEMP 'rustup-init.exe'
+          Invoke-WebRequest 'https://win.rustup.rs/x86_64' -OutFile $installer
+          Start-Process -FilePath $installer -ArgumentList '-y', '--default-toolchain', 'none', '--profile', 'minimal' -Wait -NoNewWindow
+          $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
+          $cargoBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          $env:Path = "$cargoBin;$env:Path"
+        }
+
+        rustup set profile minimal
+        rustup toolchain install stable --no-self-update
+        rustup default stable
+
+        if ($env:INPUT_TARGETS) {
+          $env:INPUT_TARGETS.Split(',', [System.StringSplitOptions]::RemoveEmptyEntries) | ForEach-Object {
+            rustup target add $_ --toolchain stable
+          }
+        }
+
+        rustc --version --verbose
+        cargo --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -56,7 +56,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust
 
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## What

Replace the external `dtolnay/rust-toolchain@stable` action in the desktop smoke and desktop bundle workflows with a repo-local Rust bootstrap action that uses `rustup` directly.

## Why

`main` is currently flaking on macOS during workflow setup before checkout/build begins. The failure is not in app code; GitHub Actions is intermittently failing to download the `dtolnay/rust-toolchain` action tarball for macOS jobs.

That leaves `Desktop Smoke (macOS)` and `Bundle (macOS Apple Silicon)` red on otherwise healthy commits. Using a local action removes that extra third-party action fetch while keeping the same stable Rust toolchain behavior.

## How

- added `.github/actions/setup-rust/action.yml`
- install stable Rust with `rustup` directly on Unix and Windows runners
- keep optional target installation for bundle builds
- switched `.github/workflows/desktop-e2e.yml` to the local Rust setup action
- switched `.github/workflows/build.yml` to the local Rust setup action

## Related Issue

Closes #70

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests
- [x] CI / tooling
- [ ] Chore (dependencies, config)

## Testing

- [x] YAML parsed locally with Ruby `YAML.load_file` for the new local action and both workflows
- [x] Verified no remaining `dtolnay/rust-toolchain` references in tracked workflows
- [ ] GitHub Actions validation on this PR

Commands run:

```bash
ruby -e "require 'yaml'; %w[.github/actions/setup-rust/action.yml .github/workflows/build.yml .github/workflows/desktop-e2e.yml].each { |f| YAML.load_file(f); puts \"OK #{f}\" }"
rg -n "dtolnay/rust-toolchain|uses: \\./\\.github/actions/setup-rust" .github
```
