### PR TITLE
feat(cli): brand serve startup and package install smoke

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,17 +68,14 @@ jobs:
 
       - name: Pack published tarball
         id: pack
-        run: |
-          npm pack --json > pack-result.json
-          node -e "const fs=require('node:fs'); const data=JSON.parse(fs.readFileSync('pack-result.json','utf8')); fs.appendFileSync(process.env.GITHUB_OUTPUT, 'tarball=' + data[0].filename + '\\n')"
+        run: node tests/install/github-actions.mjs pack-output
 
       - name: Install tarball globally
         run: npm install -g "./${{ steps.pack.outputs.tarball }}"
 
       - name: Locate installed CLI binary
         id: binary
-        run: |
-          node -e "const { execFileSync } = require('node:child_process'); const fs = require('node:fs'); const path = require('node:path'); const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'; const prefix = execFileSync(npmCommand, ['prefix', '-g'], { encoding: 'utf8' }).trim(); const binary = process.platform === 'win32' ? path.join(prefix, 'clawmaster.cmd') : path.join(prefix, 'bin', 'clawmaster'); fs.appendFileSync(process.env.GITHUB_OUTPUT, 'path=' + binary + '\\n')"
+        run: node tests/install/github-actions.mjs binary-output
 
       - name: Smoke test packaged install
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,41 @@ jobs:
       - name: Build web
         run: npm run build
 
+  package-install-smoke:
+    name: Packaged Install Smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - run: npm ci
+
+      - name: Pack published tarball
+        id: pack
+        run: |
+          npm pack --json > pack-result.json
+          node -e "const fs=require('node:fs'); const data=JSON.parse(fs.readFileSync('pack-result.json','utf8')); fs.appendFileSync(process.env.GITHUB_OUTPUT, 'tarball=' + data[0].filename + '\\n')"
+
+      - name: Install tarball globally
+        run: npm install -g "./${{ steps.pack.outputs.tarball }}"
+
+      - name: Locate installed CLI binary
+        id: binary
+        run: |
+          node -e "const { execFileSync } = require('node:child_process'); const fs = require('node:fs'); const path = require('node:path'); const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'; const prefix = execFileSync(npmCommand, ['prefix', '-g'], { encoding: 'utf8' }).trim(); const binary = process.platform === 'win32' ? path.join(prefix, 'clawmaster.cmd') : path.join(prefix, 'bin', 'clawmaster'); fs.appendFileSync(process.env.GITHUB_OUTPUT, 'path=' + binary + '\\n')"
+
+      - name: Smoke test packaged install
+        env:
+          CLAWMASTER_BINARY: ${{ steps.binary.outputs.path }}
+        run: node tests/install/package-install-smoke.mjs
+
   # ─── Backend Integration Tests ───
   backend:
     name: Backend Integration

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ clawmaster doctor            # verify your environment
 clawmaster serve             # start the web console
 ```
 
-Open `http://127.0.0.1:3001` in your browser and enter the token printed in the terminal.
+`clawmaster serve` prints the bind address and token, then opens the web console in your default browser. Pass `--silent` to skip the banner and browser launch.
 
 ```bash
 clawmaster serve --daemon    # run in background

--- a/README_CN.md
+++ b/README_CN.md
@@ -67,7 +67,7 @@ clawmaster doctor            # 检查环境
 clawmaster serve             # 启动 Web 控制台
 ```
 
-在浏览器中打开 `http://127.0.0.1:3001`，输入终端中打印的令牌即可使用。
+`clawmaster serve` 会打印绑定地址和令牌，并默认在浏览器中打开 Web 控制台。传入 `--silent` 可跳过横幅和自动打开浏览器。
 
 ```bash
 clawmaster serve --daemon    # 后台运行

--- a/README_JP.md
+++ b/README_JP.md
@@ -67,7 +67,7 @@ clawmaster doctor            # 環境を確認
 clawmaster serve             # Web コンソールを起動
 ```
 
-ブラウザで `http://127.0.0.1:3001` を開き、ターミナルに表示されたトークンを入力してください。
+`clawmaster serve` はバインド先とトークンを表示し、既定では Web コンソールをブラウザで開きます。バナー表示と自動起動を止めたい場合は `--silent` を使ってください。
 
 ```bash
 clawmaster serve --daemon    # バックグラウンド実行

--- a/bin/clawmaster.mjs
+++ b/bin/clawmaster.mjs
@@ -473,20 +473,6 @@ async function fetchServiceInfo(baseUrl, options = {}) {
   throw lastError ?? new Error('unknown service probe failure')
 }
 
-async function waitForServiceReady(baseUrl, options = {}) {
-  try {
-    await fetchServiceInfo(baseUrl, {
-      retries: options.retries ?? SERVICE_READY_RETRIES,
-      retryDelayMs: options.retryDelayMs ?? SERVICE_READY_RETRY_DELAY_MS,
-      timeoutMs: options.timeoutMs ?? SERVICE_READY_TIMEOUT_MS,
-      token: options.token ?? '',
-    })
-    return true
-  } catch {
-    return false
-  }
-}
-
 export async function waitForUrlReady(targetUrl, options = {}) {
   const {
     retries = SERVICE_READY_RETRIES,
@@ -770,15 +756,12 @@ async function runServe(args) {
   })
 
   if (daemon) {
-    try {
-      await fetchServiceInfo(url, {
-        retries: SERVICE_READY_RETRIES,
-        retryDelayMs: SERVICE_READY_RETRY_DELAY_MS,
-        timeoutMs: SERVICE_READY_TIMEOUT_MS,
-        token,
-      })
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
+    const ready = await waitForUrlReady(url, {
+      retries: SERVICE_READY_RETRIES,
+      retryDelayMs: SERVICE_READY_RETRY_DELAY_MS,
+      timeoutMs: SERVICE_READY_TIMEOUT_MS,
+    })
+    if (!ready) {
       try {
         process.kill(child.pid, 'SIGTERM')
       } catch {
@@ -786,7 +769,7 @@ async function runServe(args) {
       }
       const stderrTail = readLogTail(stderrLog).trim()
       clearServiceState()
-      console.error(`ClawMaster service failed to become ready at ${url}: ${message}`)
+      console.error(`ClawMaster web console failed to become ready at ${url}.`)
       if (stderrTail) {
         console.error('')
         console.error('Recent stderr:')

--- a/bin/clawmaster.mjs
+++ b/bin/clawmaster.mjs
@@ -295,7 +295,7 @@ export function formatServeReadyMessage({
   if (browserRequested) {
     lines.push(formatServeStatusLine(
       'browser:',
-      ready ? 'opening the default browser' : 'auto-open skipped until the service answers',
+      ready ? 'opening the default browser' : 'opening when the web console becomes reachable',
     ))
   }
   lines.push(formatServeStatusLine(
@@ -485,6 +485,47 @@ async function waitForServiceReady(baseUrl, options = {}) {
   } catch {
     return false
   }
+}
+
+export async function waitForUrlReady(targetUrl, options = {}) {
+  const {
+    retries = SERVICE_READY_RETRIES,
+    retryDelayMs = SERVICE_READY_RETRY_DELAY_MS,
+    timeoutMs = SERVICE_READY_TIMEOUT_MS,
+    fetchImpl = fetch,
+  } = options
+
+  for (let attempt = 0; attempt < retries; attempt += 1) {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), timeoutMs)
+    try {
+      const response = await fetchImpl(targetUrl, {
+        signal: controller.signal,
+      })
+      if (response.ok) {
+        return true
+      }
+    } catch {
+      // ignore transient startup failures
+    } finally {
+      clearTimeout(timer)
+    }
+
+    if (attempt < retries - 1) {
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs))
+    }
+  }
+
+  return false
+}
+
+function openBrowserWhenReady(targetUrl, options = {}) {
+  void (async () => {
+    const ready = await waitForUrlReady(targetUrl, options)
+    if (ready) {
+      requestBrowserOpen(targetUrl, options)
+    }
+  })()
 }
 
 export async function validateServiceState(state, options = {}) {
@@ -790,19 +831,15 @@ async function runServe(args) {
     process.exit(code ?? 0)
   })
 
-  const ready = await waitForServiceReady(url, { token })
-
   console.log(formatServeReadyMessage({
     daemon: false,
     urls,
     token,
     browserRequested: !silent,
-    ready,
+    ready: false,
   }))
   if (!silent) {
-    if (ready) {
-      requestBrowserOpen(launchUrl)
-    }
+    openBrowserWhenReady(launchUrl)
   }
 }
 

--- a/bin/clawmaster.mjs
+++ b/bin/clawmaster.mjs
@@ -5,7 +5,7 @@ import { randomBytes } from 'node:crypto'
 import { spawn, execFile as execFileCallback, execFileSync } from 'node:child_process'
 import { dirname, join, posix as pathPosix, resolve, win32 as pathWin32 } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { chmodSync, closeSync, existsSync, mkdirSync, openSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, closeSync, existsSync, mkdirSync, openSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { promisify } from 'node:util'
 import os from 'node:os'
 
@@ -15,6 +15,28 @@ const root = resolve(__dirname, '..')
 const cliEntryPath = fileURLToPath(import.meta.url)
 const require = createRequire(import.meta.url)
 const pkg = require(resolve(root, 'package.json'))
+const realCliEntryPath = resolveRealPath(cliEntryPath)
+const SERVICE_READY_RETRIES = 40
+const SERVICE_READY_RETRY_DELAY_MS = 250
+const SERVICE_READY_TIMEOUT_MS = 1000
+const BANNER_PRIMARY = '\x1b[1;38;2;35;214;171m'
+const BANNER_SECONDARY = '\x1b[1;38;2;71;198;255m'
+const BANNER_VERSION = '\x1b[38;2;35;214;171m'
+const ANSI_RESET = '\x1b[0m'
+const SERVE_BANNER_LINES = [
+  ' ██████╗ ██╗      █████╗ ██╗    ██╗',
+  '██╔════╝ ██║     ██╔══██╗██║    ██║',
+  '██║      ██║     ███████║██║ █╗ ██║',
+  '██║      ██║     ██╔══██║██║███╗██║',
+  '╚██████╗ ███████╗██║  ██║╚███╔███╔╝',
+  ' ╚═════╝ ╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝ ',
+  '███╗   ███╗ █████╗ ███████╗████████╗███████╗██████╗ ',
+  '████╗ ████║██╔══██╗██╔════╝╚══██╔══╝██╔════╝██╔══██╗',
+  '██╔████╔██║███████║███████╗   ██║   █████╗  ██████╔╝',
+  '██║╚██╔╝██║██╔══██║╚════██║   ██║   ██╔══╝  ██╔══██╗',
+  '██║ ╚═╝ ██║██║  ██║███████║   ██║   ███████╗██║  ██║',
+  '╚═╝     ╚═╝╚═╝  ╚═╝╚══════╝   ╚═╝   ╚══════╝╚═╝  ╚═╝',
+]
 
 function getServiceStatePathModule(platform = process.platform) {
   return platform === 'win32' ? pathWin32 : pathPosix
@@ -62,7 +84,7 @@ function printHelp() {
 ClawMaster v${pkg.version}
 
 Usage:
-  clawmaster serve [--host 127.0.0.1] [--port 3001] [--daemon] [--token <token>]
+  clawmaster serve [--host 127.0.0.1] [--port 3001] [--daemon] [--token <token>] [--silent]
   clawmaster status [--url http://127.0.0.1:3001] [--token <token>]
   clawmaster stop
   clawmaster doctor
@@ -70,7 +92,7 @@ Usage:
   clawmaster --help
 
 Commands:
-  serve    Start the ClawMaster service in the foreground, or in the background with --daemon.
+  serve    Start the ClawMaster service and open the web console, or run it in the background with --daemon.
   status   Check whether a running ClawMaster service is reachable.
   stop     Stop the background ClawMaster service recorded in the local state file.
   doctor   Inspect local runtime prerequisites and packaged build assets.
@@ -78,6 +100,7 @@ Commands:
 Notes:
   The service expects built backend and frontend assets.
   clawmaster serve protects the web UI with a service token by default.
+  clawmaster serve opens the web console in your default browser unless you pass --silent.
   For local source checkouts, run:
     npm run build:backend
     npm run build
@@ -106,6 +129,53 @@ function hasFlag(args, name) {
 function hasValueFlag(args, name) {
   const longFlag = `--${name}`
   return args.some((arg) => arg === longFlag || arg.startsWith(`${longFlag}=`))
+}
+
+function supportsColor(stream = process.stdout, env = process.env) {
+  return Boolean(stream?.isTTY) && env.NO_COLOR === undefined && env.TERM !== 'dumb'
+}
+
+export function renderServeBanner(options = {}) {
+  const version = String(options.version ?? pkg.version)
+  const stream = options.stream ?? process.stdout
+  const env = options.env ?? process.env
+  const color = options.color ?? supportsColor(stream, env)
+  const maxWidth = SERVE_BANNER_LINES.reduce((width, line) => Math.max(width, line.length), 0)
+  const columns = Number(options.columns ?? stream?.columns ?? 0)
+  const compact = columns > 0 && columns < maxWidth + 4
+
+  if (compact) {
+    if (!color) {
+      return `CLAWMASTER v${version}`
+    }
+    return `${BANNER_PRIMARY}CLAWMASTER${ANSI_RESET} ${BANNER_SECONDARY}v${version}${ANSI_RESET}`
+  }
+
+  const versionLine = `v${version}`.padStart(maxWidth)
+  const lines = [...SERVE_BANNER_LINES, versionLine]
+  if (!color) {
+    return lines.join('\n')
+  }
+
+  return lines
+    .map((line, index) => {
+      if (index < 6) return `${BANNER_PRIMARY}${line}${ANSI_RESET}`
+      if (index < 12) return `${BANNER_SECONDARY}${line}${ANSI_RESET}`
+      return `${BANNER_VERSION}${line}${ANSI_RESET}`
+    })
+    .join('\n')
+}
+
+function printServeBanner() {
+  console.log(renderServeBanner())
+}
+
+function resolveRealPath(pathToResolve) {
+  try {
+    return realpathSync(pathToResolve)
+  } catch {
+    return null
+  }
 }
 
 function normalizeServiceUrl(value) {
@@ -146,6 +216,93 @@ export function resolveServiceUrls(host, port) {
     url: buildHttpUrl(reachableHost, port),
     wildcard: isWildcardHost(bindHost),
   }
+}
+
+export function isCliEntryInvocation(entryPath, options = {}) {
+  if (!entryPath) return false
+  const cliPath = options.cliEntryPath ?? cliEntryPath
+  const realCliPath = options.realCliEntryPath ?? realCliEntryPath
+  const resolvePath = options.resolvePath ?? resolve
+  const realpath = options.realpath ?? resolveRealPath
+  const resolvedEntryPath = resolvePath(entryPath)
+
+  if (resolvedEntryPath === cliPath) {
+    return true
+  }
+
+  const realEntryPath = realpath(resolvedEntryPath)
+  return Boolean(realEntryPath && realCliPath && realEntryPath === realCliPath)
+}
+
+export function buildServiceLaunchUrl(baseUrl, token) {
+  const url = new URL(normalizeServiceUrl(baseUrl))
+  const normalizedToken = String(token ?? '').trim()
+  if (normalizedToken) {
+    url.searchParams.set('serviceToken', normalizedToken)
+  }
+  return url.toString()
+}
+
+export function resolveBrowserOpenCommand(targetUrl, options = {}) {
+  const platform = options.platform ?? process.platform
+  if (platform === 'darwin') {
+    return { command: 'open', args: [targetUrl] }
+  }
+  if (platform === 'win32') {
+    return { command: 'rundll32.exe', args: ['url.dll,FileProtocolHandler', targetUrl] }
+  }
+  return { command: 'xdg-open', args: [targetUrl] }
+}
+
+function requestBrowserOpen(targetUrl, options = {}) {
+  const spawnImpl = options.spawnImpl ?? spawn
+  const opener = resolveBrowserOpenCommand(targetUrl, options)
+  try {
+    const child = spawnImpl(opener.command, opener.args, {
+      detached: true,
+      shell: false,
+      stdio: 'ignore',
+      windowsHide: true,
+    })
+    child.on('error', () => {})
+    child.unref()
+  } catch {
+    // best effort
+  }
+}
+
+function isServeSilent(args = []) {
+  return hasFlag(args, 'silent') || hasFlag(args, 'quiet')
+}
+
+function formatServeStatusLine(label, value) {
+  return `${label.padEnd(13)}${value}`
+}
+
+export function formatServeReadyMessage({
+  daemon = false,
+  urls,
+  token,
+  browserRequested = false,
+  ready = true,
+}) {
+  const lines = [
+    ready ? 'ClawMaster service ready.' : 'ClawMaster service is starting.',
+    formatServeStatusLine('web console:', urls.url),
+    formatServeStatusLine('bind:', `${urls.bindHost}:${urls.port}`),
+    formatServeStatusLine('token:', token),
+  ]
+  if (browserRequested) {
+    lines.push(formatServeStatusLine(
+      'browser:',
+      ready ? 'opening the default browser' : 'auto-open skipped until the service answers',
+    ))
+  }
+  lines.push(formatServeStatusLine(
+    'next:',
+    daemon ? 'clawmaster status | clawmaster stop' : 'Ctrl+C to stop',
+  ))
+  return lines.join('\n')
 }
 
 function getServiceUrl(args = []) {
@@ -314,6 +471,20 @@ async function fetchServiceInfo(baseUrl, options = {}) {
   }
 
   throw lastError ?? new Error('unknown service probe failure')
+}
+
+async function waitForServiceReady(baseUrl, options = {}) {
+  try {
+    await fetchServiceInfo(baseUrl, {
+      retries: options.retries ?? SERVICE_READY_RETRIES,
+      retryDelayMs: options.retryDelayMs ?? SERVICE_READY_RETRY_DELAY_MS,
+      timeoutMs: options.timeoutMs ?? SERVICE_READY_TIMEOUT_MS,
+      token: options.token ?? '',
+    })
+    return true
+  } catch {
+    return false
+  }
 }
 
 export async function validateServiceState(state, options = {}) {
@@ -485,10 +656,12 @@ async function runServe(args) {
   const host = getBackendHost(args)
   const port = getBackendPort(args)
   const daemon = hasFlag(args, 'daemon')
+  const silent = isServeSilent(args)
   const token = getServiceToken(args)
   const assets = resolveServiceAssets()
   const urls = resolveServiceUrls(host, port)
   const url = urls.url
+  const launchUrl = buildServiceLaunchUrl(url, token)
   const running = await getRunningServiceState({ allowUnreachable: false })
   const { serviceStateDir } = resolveServiceStatePaths()
   const stdoutLog = join(serviceStateDir, 'service.stdout.log')
@@ -508,6 +681,10 @@ async function runServe(args) {
     console.error(`ClawMaster service is already running at ${running.url} (pid ${running.pid}).`)
     console.error('Use `clawmaster status` to inspect it or `clawmaster stop` to stop it first.')
     process.exit(1)
+  }
+
+  if (!silent) {
+    printServeBanner()
   }
 
   ensureServiceStateDir()
@@ -553,7 +730,12 @@ async function runServe(args) {
 
   if (daemon) {
     try {
-      await fetchServiceInfo(url, { retries: 40, retryDelayMs: 250, timeoutMs: 1000, token })
+      await fetchServiceInfo(url, {
+        retries: SERVICE_READY_RETRIES,
+        retryDelayMs: SERVICE_READY_RETRY_DELAY_MS,
+        timeoutMs: SERVICE_READY_TIMEOUT_MS,
+        token,
+      })
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       try {
@@ -573,22 +755,18 @@ async function runServe(args) {
     }
 
     child.unref()
-    console.log(`Started ClawMaster service in the background at ${url}`)
-    if (urls.wildcard) {
-      console.log(`bound: ${host}:${port}`)
+    if (!silent) {
+      console.log(formatServeReadyMessage({
+        daemon: true,
+        urls,
+        token,
+        browserRequested: true,
+        ready: true,
+      }))
+      requestBrowserOpen(launchUrl)
     }
-    console.log(`pid: ${child.pid}`)
-    console.log(`token: ${token}`)
-    console.log('Use `clawmaster status` to inspect it and `clawmaster stop` to stop it.')
     return
   }
-
-  console.log(`Starting ClawMaster service on ${url}`)
-  if (urls.wildcard) {
-    console.log(`bound: ${host}:${port}`)
-  }
-  console.log(`token: ${token}`)
-  console.log('Press Ctrl+C to stop.')
 
   const stopChild = (signal) => {
     if (!child.killed) {
@@ -601,7 +779,6 @@ async function runServe(args) {
 
   process.on('SIGINT', handleSigint)
   process.on('SIGTERM', handleSigterm)
-
   child.on('exit', (code, signal) => {
     clearServiceState()
     process.off('SIGINT', handleSigint)
@@ -612,6 +789,21 @@ async function runServe(args) {
     }
     process.exit(code ?? 0)
   })
+
+  const ready = await waitForServiceReady(url, { token })
+
+  if (!silent) {
+    console.log(formatServeReadyMessage({
+      daemon: false,
+      urls,
+      token,
+      browserRequested: true,
+      ready,
+    }))
+    if (ready) {
+      requestBrowserOpen(launchUrl)
+    }
+  }
 }
 
 async function main() {
@@ -654,6 +846,6 @@ async function main() {
   process.exitCode = 1
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === cliEntryPath) {
+if (isCliEntryInvocation(process.argv[1])) {
   void main()
 }

--- a/bin/clawmaster.mjs
+++ b/bin/clawmaster.mjs
@@ -583,7 +583,7 @@ async function runDoctor() {
 
 async function runStatus(args) {
   const baseUrl = normalizeServiceUrl(getServiceUrl(args))
-  const storedState = await getRunningServiceState({ allowUnreachable: false })
+  const storedState = await getRunningServiceState({ allowUnreachable: true })
   const explicitUrl = hasValueFlag(args, 'url')
   const state = storedState && (!explicitUrl || normalizeServiceUrl(storedState.url) === baseUrl)
     ? storedState

--- a/bin/clawmaster.mjs
+++ b/bin/clawmaster.mjs
@@ -755,14 +755,14 @@ async function runServe(args) {
     }
 
     child.unref()
+    console.log(formatServeReadyMessage({
+      daemon: true,
+      urls,
+      token,
+      browserRequested: !silent,
+      ready: true,
+    }))
     if (!silent) {
-      console.log(formatServeReadyMessage({
-        daemon: true,
-        urls,
-        token,
-        browserRequested: true,
-        ready: true,
-      }))
       requestBrowserOpen(launchUrl)
     }
     return
@@ -792,14 +792,14 @@ async function runServe(args) {
 
   const ready = await waitForServiceReady(url, { token })
 
+  console.log(formatServeReadyMessage({
+    daemon: false,
+    urls,
+    token,
+    browserRequested: !silent,
+    ready,
+  }))
   if (!silent) {
-    console.log(formatServeReadyMessage({
-      daemon: false,
-      urls,
-      token,
-      browserRequested: true,
-      ready,
-    }))
     if (ready) {
       requestBrowserOpen(launchUrl)
     }

--- a/bin/clawmaster.mjs
+++ b/bin/clawmaster.mjs
@@ -607,7 +607,7 @@ async function runStatus(args) {
 }
 
 async function runStop() {
-  const state = await getRunningServiceState({ allowUnreachable: false })
+  const state = await getRunningServiceState({ allowUnreachable: true })
   if (!state) {
     console.error('No running ClawMaster background service was found.')
     process.exitCode = 1

--- a/bin/clawmaster.test.mjs
+++ b/bin/clawmaster.test.mjs
@@ -446,12 +446,15 @@ test('status --url does not reuse local daemon token or metadata for a different
     })
 
     const { stdout } = await runCli(['status', '--url', url], tempHome)
+    const persistedState = JSON.parse(readFileSync(path.join(tempHome, '.clawmaster', 'service', 'service-state.json'), 'utf8'))
 
     assert.match(stdout, new RegExp(`ClawMaster service is reachable at ${url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`))
     assert.doesNotMatch(stdout, /pid:\s+/)
     assert.doesNotMatch(stdout, /started:\s+/)
     assert.equal(requests[0]?.url, '/api/system/detect')
     assert.equal(requests[0]?.authorization, undefined)
+    assert.equal(persistedState.pid, process.pid)
+    assert.equal(persistedState.token, 'local-service-token')
   } finally {
     await new Promise((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()))

--- a/bin/clawmaster.test.mjs
+++ b/bin/clawmaster.test.mjs
@@ -150,6 +150,21 @@ test('formatServeReadyMessage clearly reports the console and bind addresses', (
   assert.match(message, /next:\s+clawmaster status \| clawmaster stop/)
 })
 
+test('formatServeReadyMessage describes deferred foreground browser launch without skipping it', () => {
+  const message = cliModule.formatServeReadyMessage({
+    daemon: false,
+    urls: cliModule.resolveServiceUrls('127.0.0.1', '3001'),
+    token: 'secret-token',
+    browserRequested: true,
+    ready: false,
+  })
+
+  assert.match(message, /ClawMaster service is starting\./)
+  assert.match(message, /browser:\s+opening when the web console becomes reachable/)
+  assert.match(message, /next:\s+Ctrl\+C to stop/)
+  assert.doesNotMatch(message, /skipped/i)
+})
+
 test('resolveServiceStatePaths prefers an explicit Windows HOME override', () => {
   assert.deepEqual(
     cliModule.resolveServiceStatePaths({
@@ -226,6 +241,44 @@ test('validateServiceState rejects unreachable recorded daemons when callers req
   )
 
   assert.equal(result, null)
+})
+
+test('waitForUrlReady succeeds when the web console url responds even if detect would be slower', async () => {
+  const server = createServer((req, res) => {
+    if (req.url?.startsWith('/api/system/detect')) {
+      setTimeout(() => {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ runtime: { mode: 'native' } }))
+      }, 500)
+      return
+    }
+
+    res.writeHead(200, { 'Content-Type': 'text/html' })
+    res.end('<!doctype html><title>ClawMaster</title>')
+  })
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.listen(0, '127.0.0.1', (error) => (error ? reject(error) : resolve()))
+    })
+    const address = server.address()
+    assert.ok(address && typeof address === 'object')
+
+    const ready = await cliModule.waitForUrlReady(
+      `http://127.0.0.1:${address.port}/?serviceToken=secret-token`,
+      {
+        retries: 2,
+        retryDelayMs: 10,
+        timeoutMs: 100,
+      },
+    )
+
+    assert.equal(ready, true)
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()))
+    })
+  }
 })
 
 test('validateServiceState drops dead recorded daemons', async () => {

--- a/bin/clawmaster.test.mjs
+++ b/bin/clawmaster.test.mjs
@@ -62,6 +62,94 @@ test('resolveServiceUrls maps wildcard hosts to local probe urls', () => {
   })
 })
 
+test('buildServiceLaunchUrl appends the service token for browser auto-open', () => {
+  assert.equal(
+    cliModule.buildServiceLaunchUrl('http://127.0.0.1:3001', 'secret-token'),
+    'http://127.0.0.1:3001/?serviceToken=secret-token',
+  )
+})
+
+test('resolveBrowserOpenCommand picks the native opener for each platform', () => {
+  assert.deepEqual(
+    cliModule.resolveBrowserOpenCommand('http://127.0.0.1:3001', { platform: 'darwin' }),
+    { command: 'open', args: ['http://127.0.0.1:3001'] },
+  )
+  assert.deepEqual(
+    cliModule.resolveBrowserOpenCommand('http://127.0.0.1:3001', { platform: 'linux' }),
+    { command: 'xdg-open', args: ['http://127.0.0.1:3001'] },
+  )
+  assert.deepEqual(
+    cliModule.resolveBrowserOpenCommand('http://127.0.0.1:3001', { platform: 'win32' }),
+    { command: 'rundll32.exe', args: ['url.dll,FileProtocolHandler', 'http://127.0.0.1:3001'] },
+  )
+})
+
+test('isCliEntryInvocation treats npm-installed symlinks as the CLI entry', () => {
+  assert.equal(
+    cliModule.isCliEntryInvocation('/opt/homebrew/bin/clawmaster', {
+      cliEntryPath: '/opt/homebrew/lib/node_modules/clawmaster/bin/clawmaster.mjs',
+      realCliEntryPath: '/opt/homebrew/lib/node_modules/clawmaster/bin/clawmaster.mjs',
+      resolvePath: (value) => value,
+      realpath: (value) => value === '/opt/homebrew/bin/clawmaster'
+        ? '/opt/homebrew/lib/node_modules/clawmaster/bin/clawmaster.mjs'
+        : value,
+    }),
+    true,
+  )
+})
+
+test('isCliEntryInvocation rejects unrelated binaries', () => {
+  assert.equal(
+    cliModule.isCliEntryInvocation('/opt/homebrew/bin/not-clawmaster', {
+      cliEntryPath: '/opt/homebrew/lib/node_modules/clawmaster/bin/clawmaster.mjs',
+      realCliEntryPath: '/opt/homebrew/lib/node_modules/clawmaster/bin/clawmaster.mjs',
+      resolvePath: (value) => value,
+      realpath: () => '/opt/homebrew/lib/node_modules/other/bin/not-clawmaster.mjs',
+    }),
+    false,
+  )
+})
+
+test('renderServeBanner falls back to compact plain text on narrow terminals', () => {
+  assert.equal(
+    cliModule.renderServeBanner({
+      color: false,
+      columns: 20,
+      version: '9.9.9',
+    }),
+    'CLAWMASTER v9.9.9',
+  )
+})
+
+test('renderServeBanner can render a plain-text full banner without ANSI escapes', () => {
+  const banner = cliModule.renderServeBanner({
+    color: false,
+    columns: 120,
+    version: '9.9.9',
+  })
+
+  assert.match(banner, /v9\.9\.9/)
+  assert.ok(banner.split('\n').length >= 13)
+  assert.doesNotMatch(banner, /\x1b\[/)
+})
+
+test('formatServeReadyMessage clearly reports the console and bind addresses', () => {
+  const message = cliModule.formatServeReadyMessage({
+    daemon: true,
+    urls: cliModule.resolveServiceUrls('0.0.0.0', '3001'),
+    token: 'secret-token',
+    browserRequested: true,
+    ready: true,
+  })
+
+  assert.match(message, /ClawMaster service ready\./)
+  assert.match(message, /web console:\s+http:\/\/127\.0\.0\.1:3001/)
+  assert.match(message, /bind:\s+0\.0\.0\.0:3001/)
+  assert.match(message, /token:\s+secret-token/)
+  assert.match(message, /browser:\s+opening the default browser/)
+  assert.match(message, /next:\s+clawmaster status \| clawmaster stop/)
+})
+
 test('resolveServiceStatePaths prefers an explicit Windows HOME override', () => {
   assert.deepEqual(
     cliModule.resolveServiceStatePaths({
@@ -248,6 +336,17 @@ test('buildServiceSpawnOptions propagates a Windows HOME override to backend env
   assert.equal(options.env.USERPROFILE, '\\\\server\\share\\portable-home')
   assert.equal(options.env.APPDATA, '\\\\server\\share\\portable-home\\AppData\\Roaming')
   assert.equal(options.env.LOCALAPPDATA, '\\\\server\\share\\portable-home\\AppData\\Local')
+})
+
+test('help documents serve silent mode and browser auto-open', async () => {
+  const tempHome = createTempHome()
+  try {
+    const { stdout } = await runCli(['--help'], tempHome)
+    assert.match(stdout, /serve \[--host 127\.0\.0\.1] \[--port 3001] \[--daemon] \[--token <token>] \[--silent]/)
+    assert.match(stdout, /opens the web console in your default browser unless you pass --silent/i)
+  } finally {
+    rmSync(tempHome, { recursive: true, force: true })
+  }
 })
 
 test('status --url does not reuse local daemon token or metadata for a different target', async () => {

--- a/bin/clawmaster.test.mjs
+++ b/bin/clawmaster.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { execFile as execFileCallback } from 'node:child_process'
+import { execFile as execFileCallback, spawn } from 'node:child_process'
 import { createServer } from 'node:http'
 import { closeSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
@@ -30,6 +30,19 @@ async function runCli(args, homeDir) {
       ...process.env,
       HOME: homeDir,
     },
+  })
+}
+
+async function waitForExit(child) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return {
+      code: child.exitCode,
+      signal: child.signalCode,
+    }
+  }
+  return new Promise((resolve, reject) => {
+    child.once('exit', (code, signal) => resolve({ code, signal }))
+    child.once('error', reject)
   })
 }
 
@@ -495,6 +508,45 @@ test('status reuses the local daemon token and metadata for the recorded service
     await new Promise((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()))
     })
+    rmSync(tempHome, { recursive: true, force: true })
+  }
+})
+
+test('stop kills a recorded live daemon even if the service probe is unreachable', async () => {
+  const tempHome = createTempHome()
+  const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+    detached: process.platform !== 'win32',
+    stdio: 'ignore',
+    windowsHide: true,
+  })
+
+  if (process.platform !== 'win32') {
+    child.unref()
+  }
+
+  writeServiceState(tempHome, {
+    pid: child.pid,
+    url: 'http://127.0.0.1:9',
+    token: 'stale-token',
+    startedAt: '2026-04-11T00:00:00.000Z',
+  })
+
+  try {
+    const { stdout, stderr } = await runCli(['stop'], tempHome)
+    assert.equal(stderr, '')
+    assert.match(stdout, new RegExp(`Stopped ClawMaster service \\(pid ${child.pid}\\)\\.`))
+
+    const exit = await Promise.race([
+      waitForExit(child),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('timed out waiting for daemon to stop')), 5000)),
+    ])
+    assert.ok(exit)
+  } finally {
+    try {
+      process.kill(child.pid, 'SIGKILL')
+    } catch {
+      // best effort in case the CLI already stopped it
+    }
     rmSync(tempHome, { recursive: true, force: true })
   }
 })

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -78,7 +78,7 @@ export function startServer() {
     const uiStatus = frontendDist
       ? `serving UI from ${frontendDist}`
       : 'UI assets not found; API only'
-    console.log(`OpenClaw Manager Service on http://${host}:${port} (${uiStatus})`)
+    console.log(`ClawMaster service listening on http://${host}:${port} (${uiStatus})`)
   })
 
   attachLogsStreamServer(server)

--- a/tests/install/github-actions.mjs
+++ b/tests/install/github-actions.mjs
@@ -1,0 +1,70 @@
+import { execFileSync, spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+function getNpmCommand() {
+  return process.platform === 'win32' ? 'npm.cmd' : 'npm'
+}
+
+function getNpmExecOptions() {
+  return {
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+  }
+}
+
+function appendGitHubOutput(key, value) {
+  const outputPath = process.env.GITHUB_OUTPUT
+  if (!outputPath) {
+    throw new Error('GITHUB_OUTPUT is not set')
+  }
+  fs.appendFileSync(outputPath, `${key}=${value}\n`)
+}
+
+function extractTrailingJsonArray(stdout) {
+  const match = String(stdout ?? '').match(/(\[\s*{[\s\S]*}\s*\])\s*$/)
+  if (!match) {
+    throw new Error('npm pack --json did not end with a JSON array payload')
+  }
+
+  return {
+    logs: stdout.slice(0, match.index ?? 0),
+    jsonText: match[1],
+    data: JSON.parse(match[1]),
+  }
+}
+
+function resolveGlobalBinaryPath() {
+  const prefix = execFileSync(getNpmCommand(), ['prefix', '-g'], getNpmExecOptions()).trim()
+  return process.platform === 'win32'
+    ? path.join(prefix, 'clawmaster.cmd')
+    : path.join(prefix, 'bin', 'clawmaster')
+}
+
+function writePackOutput() {
+  const result = spawnSync(getNpmCommand(), ['pack', '--json'], getNpmExecOptions())
+  if (result.status !== 0) {
+    if (result.stdout) process.stdout.write(result.stdout)
+    if (result.stderr) process.stderr.write(result.stderr)
+    process.exit(result.status ?? 1)
+  }
+
+  const payload = extractTrailingJsonArray(result.stdout)
+  if (payload.logs) process.stdout.write(payload.logs)
+  fs.writeFileSync('pack-result.json', `${payload.jsonText}\n`, 'utf8')
+  appendGitHubOutput('tarball', payload.data[0].filename)
+}
+
+function writeBinaryOutput() {
+  appendGitHubOutput('path', resolveGlobalBinaryPath())
+}
+
+const command = process.argv[2] ?? ''
+
+if (command === 'pack-output') {
+  writePackOutput()
+} else if (command === 'binary-output') {
+  writeBinaryOutput()
+} else {
+  throw new Error(`Unknown command: ${command}`)
+}

--- a/tests/install/package-install-smoke.mjs
+++ b/tests/install/package-install-smoke.mjs
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict'
+import { execFileSync, spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
+const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'))
+const smokePort = String(Number.parseInt(process.env.CLAWMASTER_SMOKE_PORT ?? '3411', 10))
+const smokeToken = process.env.CLAWMASTER_SMOKE_TOKEN?.trim() || 'ci-install-smoke-token'
+const smokeUrl = `http://127.0.0.1:${smokePort}`
+
+function resolveInstalledBinary() {
+  if (process.env.CLAWMASTER_BINARY?.trim()) {
+    return process.env.CLAWMASTER_BINARY.trim()
+  }
+  const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+  const prefix = execFileSync(npmCommand, ['prefix', '-g'], { encoding: 'utf8' }).trim()
+  return process.platform === 'win32'
+    ? path.join(prefix, 'clawmaster.cmd')
+    : path.join(prefix, 'bin', 'clawmaster')
+}
+
+function formatCommand(binary, args) {
+  return [binary, ...args].join(' ')
+}
+
+function assertSuccess(result, binary, args) {
+  assert.equal(
+    result.status,
+    0,
+    `${formatCommand(binary, args)} failed with exit ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  )
+}
+
+async function waitForHealthyStatus(binary, env) {
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const result = spawnSync(binary, ['status', '--url', smokeUrl, '--token', smokeToken], {
+      encoding: 'utf8',
+      env,
+    })
+    if (result.status === 0) {
+      return result.stdout
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+  throw new Error(`Timed out waiting for ${smokeUrl} to become reachable.`)
+}
+
+const binary = resolveInstalledBinary()
+const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'clawmaster-install-smoke-'))
+const env = {
+  ...process.env,
+  HOME: tempHome,
+  USERPROFILE: tempHome,
+}
+
+if (process.platform === 'win32') {
+  env.APPDATA = path.win32.join(tempHome, 'AppData', 'Roaming')
+  env.LOCALAPPDATA = path.win32.join(tempHome, 'AppData', 'Local')
+}
+
+try {
+  const versionResult = spawnSync(binary, ['--version'], { encoding: 'utf8', env })
+  assertSuccess(versionResult, binary, ['--version'])
+  assert.match(versionResult.stdout, new RegExp(`ClawMaster v${pkg.version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`))
+
+  const helpResult = spawnSync(binary, ['--help'], { encoding: 'utf8', env })
+  assertSuccess(helpResult, binary, ['--help'])
+  assert.match(helpResult.stdout, /--silent/)
+
+  const doctorResult = spawnSync(binary, ['doctor'], { encoding: 'utf8', env })
+  assertSuccess(doctorResult, binary, ['doctor'])
+  assert.doesNotMatch(doctorResult.stdout, /missing build output/i)
+
+  const serveArgs = ['serve', '--daemon', '--silent', '--host', '127.0.0.1', '--port', smokePort, '--token', smokeToken]
+  const serveResult = spawnSync(binary, serveArgs, { encoding: 'utf8', env })
+  assertSuccess(serveResult, binary, serveArgs)
+
+  const statusOutput = await waitForHealthyStatus(binary, env)
+  assert.match(statusOutput, new RegExp(`ClawMaster service is reachable at ${smokeUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`))
+
+  const stopResult = spawnSync(binary, ['stop'], { encoding: 'utf8', env })
+  assertSuccess(stopResult, binary, ['stop'])
+  assert.match(stopResult.stdout, /Stopped ClawMaster service/)
+} finally {
+  spawnSync(binary, ['stop'], { encoding: 'utf8', env })
+  fs.rmSync(tempHome, { recursive: true, force: true })
+}

--- a/tests/install/package-install-smoke.mjs
+++ b/tests/install/package-install-smoke.mjs
@@ -54,6 +54,44 @@ function runBinary(binary, args, env) {
   return spawnSync(binary, args, getBinaryExecOptions(env))
 }
 
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function isIgnorableWindowsCleanupError(error) {
+  if (process.platform !== 'win32') {
+    return false
+  }
+  const code = error && typeof error === 'object' && 'code' in error ? error.code : ''
+  return code === 'ENOTEMPTY' || code === 'EPERM' || code === 'EBUSY'
+}
+
+async function cleanupTempHome(binary, env, tempHome) {
+  runBinary(binary, ['stop'], env)
+
+  // Windows runners can keep the detached daemon's log directory busy briefly
+  // after `clawmaster stop` succeeds. Cleanup is best effort; the smoke signal
+  // is whether install/start/status/stop work, not whether the temp dir deletes
+  // immediately on the runner filesystem.
+  const attempts = process.platform === 'win32' ? 12 : 1
+  const delayMs = process.platform === 'win32' ? 1000 : 0
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      fs.rmSync(tempHome, { recursive: true, force: true })
+      return
+    } catch (error) {
+      if (!isIgnorableWindowsCleanupError(error) || attempt === attempts - 1) {
+        if (isIgnorableWindowsCleanupError(error)) {
+          return
+        }
+        throw error
+      }
+      await sleep(delayMs)
+    }
+  }
+}
+
 async function waitForHealthyStatus(binary, env) {
   for (let attempt = 0; attempt < 8; attempt += 1) {
     const result = runBinary(binary, ['status', '--url', smokeUrl, '--token', smokeToken], env)
@@ -67,12 +105,6 @@ async function waitForHealthyStatus(binary, env) {
 
 const binary = resolveInstalledBinary()
 const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'clawmaster-install-smoke-'))
-const cleanupRmOptions = {
-  recursive: true,
-  force: true,
-  maxRetries: process.platform === 'win32' ? 20 : 0,
-  retryDelay: 200,
-}
 const env = {
   ...process.env,
   HOME: tempHome,
@@ -111,6 +143,5 @@ try {
   assertSuccess(stopResult, binary, ['stop'])
   assert.match(stopResult.stdout, /Stopped ClawMaster service/)
 } finally {
-  runBinary(binary, ['stop'], env)
-  fs.rmSync(tempHome, cleanupRmOptions)
+  await cleanupTempHome(binary, env, tempHome)
 }

--- a/tests/install/package-install-smoke.mjs
+++ b/tests/install/package-install-smoke.mjs
@@ -11,12 +11,19 @@ const smokePort = String(Number.parseInt(process.env.CLAWMASTER_SMOKE_PORT ?? '3
 const smokeToken = process.env.CLAWMASTER_SMOKE_TOKEN?.trim() || 'ci-install-smoke-token'
 const smokeUrl = `http://127.0.0.1:${smokePort}`
 
+function getNpmExecOptions() {
+  return {
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+  }
+}
+
 function resolveInstalledBinary() {
   if (process.env.CLAWMASTER_BINARY?.trim()) {
     return process.env.CLAWMASTER_BINARY.trim()
   }
   const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
-  const prefix = execFileSync(npmCommand, ['prefix', '-g'], { encoding: 'utf8' }).trim()
+  const prefix = execFileSync(npmCommand, ['prefix', '-g'], getNpmExecOptions()).trim()
   return process.platform === 'win32'
     ? path.join(prefix, 'clawmaster.cmd')
     : path.join(prefix, 'bin', 'clawmaster')
@@ -77,6 +84,9 @@ try {
   const serveArgs = ['serve', '--daemon', '--silent', '--host', '127.0.0.1', '--port', smokePort, '--token', smokeToken]
   const serveResult = spawnSync(binary, serveArgs, { encoding: 'utf8', env })
   assertSuccess(serveResult, binary, serveArgs)
+  assert.match(serveResult.stdout, new RegExp(`web console:\\s+${smokeUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`))
+  assert.match(serveResult.stdout, new RegExp(`token:\\s+${smokeToken.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`))
+  assert.doesNotMatch(serveResult.stdout, /browser:\s+/)
 
   const statusOutput = await waitForHealthyStatus(binary, env)
   assert.match(statusOutput, new RegExp(`ClawMaster service is reachable at ${smokeUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`))

--- a/tests/install/package-install-smoke.mjs
+++ b/tests/install/package-install-smoke.mjs
@@ -67,6 +67,12 @@ async function waitForHealthyStatus(binary, env) {
 
 const binary = resolveInstalledBinary()
 const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'clawmaster-install-smoke-'))
+const cleanupRmOptions = {
+  recursive: true,
+  force: true,
+  maxRetries: process.platform === 'win32' ? 20 : 0,
+  retryDelay: 200,
+}
 const env = {
   ...process.env,
   HOME: tempHome,
@@ -106,5 +112,5 @@ try {
   assert.match(stopResult.stdout, /Stopped ClawMaster service/)
 } finally {
   runBinary(binary, ['stop'], env)
-  fs.rmSync(tempHome, { recursive: true, force: true })
+  fs.rmSync(tempHome, cleanupRmOptions)
 }

--- a/tests/install/package-install-smoke.mjs
+++ b/tests/install/package-install-smoke.mjs
@@ -18,6 +18,15 @@ function getNpmExecOptions() {
   }
 }
 
+function getBinaryExecOptions(env) {
+  return {
+    encoding: 'utf8',
+    env,
+    shell: process.platform === 'win32',
+    windowsHide: true,
+  }
+}
+
 function resolveInstalledBinary() {
   if (process.env.CLAWMASTER_BINARY?.trim()) {
     return process.env.CLAWMASTER_BINARY.trim()
@@ -41,12 +50,13 @@ function assertSuccess(result, binary, args) {
   )
 }
 
+function runBinary(binary, args, env) {
+  return spawnSync(binary, args, getBinaryExecOptions(env))
+}
+
 async function waitForHealthyStatus(binary, env) {
   for (let attempt = 0; attempt < 8; attempt += 1) {
-    const result = spawnSync(binary, ['status', '--url', smokeUrl, '--token', smokeToken], {
-      encoding: 'utf8',
-      env,
-    })
+    const result = runBinary(binary, ['status', '--url', smokeUrl, '--token', smokeToken], env)
     if (result.status === 0) {
       return result.stdout
     }
@@ -69,20 +79,20 @@ if (process.platform === 'win32') {
 }
 
 try {
-  const versionResult = spawnSync(binary, ['--version'], { encoding: 'utf8', env })
+  const versionResult = runBinary(binary, ['--version'], env)
   assertSuccess(versionResult, binary, ['--version'])
   assert.match(versionResult.stdout, new RegExp(`ClawMaster v${pkg.version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`))
 
-  const helpResult = spawnSync(binary, ['--help'], { encoding: 'utf8', env })
+  const helpResult = runBinary(binary, ['--help'], env)
   assertSuccess(helpResult, binary, ['--help'])
   assert.match(helpResult.stdout, /--silent/)
 
-  const doctorResult = spawnSync(binary, ['doctor'], { encoding: 'utf8', env })
+  const doctorResult = runBinary(binary, ['doctor'], env)
   assertSuccess(doctorResult, binary, ['doctor'])
   assert.doesNotMatch(doctorResult.stdout, /missing build output/i)
 
   const serveArgs = ['serve', '--daemon', '--silent', '--host', '127.0.0.1', '--port', smokePort, '--token', smokeToken]
-  const serveResult = spawnSync(binary, serveArgs, { encoding: 'utf8', env })
+  const serveResult = runBinary(binary, serveArgs, env)
   assertSuccess(serveResult, binary, serveArgs)
   assert.match(serveResult.stdout, new RegExp(`web console:\\s+${smokeUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`))
   assert.match(serveResult.stdout, new RegExp(`token:\\s+${smokeToken.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`))
@@ -91,10 +101,10 @@ try {
   const statusOutput = await waitForHealthyStatus(binary, env)
   assert.match(statusOutput, new RegExp(`ClawMaster service is reachable at ${smokeUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`))
 
-  const stopResult = spawnSync(binary, ['stop'], { encoding: 'utf8', env })
+  const stopResult = runBinary(binary, ['stop'], env)
   assertSuccess(stopResult, binary, ['stop'])
   assert.match(stopResult.stdout, /Stopped ClawMaster service/)
 } finally {
-  spawnSync(binary, ['stop'], { encoding: 'utf8', env })
+  runBinary(binary, ['stop'], env)
   fs.rmSync(tempHome, { recursive: true, force: true })
 }


### PR DESCRIPTION
## What
- add a branded `CLAWMASTER` startup banner to `clawmaster serve`
- print explicit `web console` and `bind` addresses, and auto-open the authenticated web console by default
- add `--silent` for headless/CI runs to skip the banner and browser launch
- add cross-platform packaged install smoke coverage for Linux, macOS, and Windows
- fix the npm-installed symlink entry path so global `clawmaster` commands execute correctly

## Why
- `serve` should make the running host and port obvious and get the console open immediately
- the published npm install path had no CI proof and was still hiding a real symlink execution bug
- CI and scripted service launches still need a quiet path that does not try to launch a browser

## How
- extended `bin/clawmaster.mjs` with banner rendering, browser launch helpers, serve summaries, `--silent`, and symlink-aware CLI entry detection
- added CLI tests for the new helpers plus the npm symlink execution case
- added `tests/install/package-install-smoke.mjs` and a new workflow matrix job that packs, globally installs, and exercises the published CLI on ubuntu/windows/macos
- updated the backend startup log branding and the README CLI docs

## Screenshots
N/A for the web UI itself; this change is CLI- and packaging-focused. Verified locally with `dev-browser` against the served console URL after token bootstrap.

## Verification
- `npm run test:cli`
- `npm test`
- local packaged install smoke via `npm pack`, `npm install -g ./clawmaster-0.1.0.tgz`, and `node tests/install/package-install-smoke.mjs`
- `dev-browser --headless` load of `http://127.0.0.1:3412/?serviceToken=...` confirmed title `ClawMaster` and stored service token

Closes #72
