### PR TITLE
ci: auto-publish to npm on tag push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,6 +233,38 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  publish-npm:
+    name: Publish to npm
+    needs: verify
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+
+      - name: Determine npm dist-tag
+        id: npm_tag
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          if printf '%s' "$VERSION" | grep -Eq -- '-(rc|beta|alpha)'; then
+            echo "tag=rc" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish
+        run: npm publish --tag ${{ steps.npm_tag.outputs.tag }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   publish-release:
     name: Publish Release Assets
     needs: bundle


### PR DESCRIPTION
## What

Add automated npm publish step to the Desktop Bundles workflow, triggered on tag pushes.

## Why

Manual `npm publish` is error-prone and requires local npm auth. This automates the npm publish step so tagging a release on main automatically publishes to npm alongside creating the GitHub release with desktop bundles.

## How

- New `publish-npm` job runs after `verify` gate (in parallel with desktop bundle builds)
- Uses `NPM_TOKEN` repo secret for authentication
- Auto-detects dist-tag: pre-release versions (`-rc`, `-beta`, `-alpha`) publish with tag `rc`, stable versions publish as `latest`
- Uses `actions/setup-node` with `registry-url` for proper npm auth