### PR TITLE
fix(ci): clean release page — un-draft, fix notes, strip garbage assets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -322,8 +322,13 @@ jobs:
           set -euo pipefail
           mkdir -p release-assets
 
+          # Only installer bundles — exclude internal JSON (ICU data, package
+          # manifests, tsconfig) that gets packaged inside Tauri resources.
           find release-bundles -type f \
-            \( -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' -o -name '*.dmg' -o -name '*.msi' -o -name '*.exe' -o -name '*.zip' -o -name '*.tar.gz' -o -name '*.sig' -o -name '*.json' \) \
+            \( -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' \
+               -o -name '*.dmg' -o -name '*.app.tar.gz' \
+               -o -name '*.msi' -o -name '*.exe' \
+               -o -name '*.sig' \) \
             -exec cp '{}' release-assets/ \;
 
           if [ -z "$(find release-assets -maxdepth 1 -type f -print -quit)" ]; then
@@ -356,39 +361,38 @@ jobs:
 
           GENERATED_BODY="$(node -e "const fs=require('fs'); const body=JSON.parse(fs.readFileSync('generated-release-notes.json','utf8')).body || ''; process.stdout.write(body.trim());")"
 
-          cat <<EOF > RELEASE_NOTES.md
-          ## Install
+          VERSION="${TAG#v}"
+          NPM_TAG="latest"
+          if printf '%s' "$VERSION" | grep -Eq -- '-(rc|beta|alpha)'; then
+            NPM_TAG="rc"
+          fi
 
-          ### CLI + Web Console (Recommended)
-
-          \`\`\`bash
-          npm install -g clawmaster@\${TAG#v}
-          clawmaster
-          \`\`\`
-
-          Open http://localhost:16223 — the setup wizard guides you through OpenClaw engine detection and LLM provider configuration.
-
-          ### Desktop App (Beta)
-
-          Download the installer for your platform from the Assets section below.
-
-          | Platform | Files |
-          |---|---|
-          | Linux x64 | \`.AppImage\`, \`.deb\`, \`.rpm\` |
-          | macOS Intel | \`.dmg\` |
-          | macOS Apple Silicon | \`.dmg\` |
-          | Windows x64 | \`.msi\`, \`.exe\` |
-
-          > **Note:** Desktop builds are in beta. The CLI + Web Console is the recommended install method.
-
-          ## Checksums
-
-          Verify downloads with \`SHA256SUMS.txt\` attached to this release.
-
-          ## What's Changed
-
-          $GENERATED_BODY
-          EOF
+          # Use printf instead of heredoc because YAML's `run: |` indentation
+          # leaks into the heredoc content — turning every heading into an
+          # indented code block in the rendered markdown.
+          {
+            printf '## Install\n\n'
+            printf '### CLI + Web Console (Recommended)\n\n'
+            printf '```bash\n'
+            printf 'npm install -g clawmaster@%s\n' "$NPM_TAG"
+            printf 'clawmaster\n'
+            printf '```\n\n'
+            printf 'Open http://localhost:16223 — the setup wizard guides you through OpenClaw engine detection and LLM provider configuration.\n\n'
+            printf '> To pin this exact version: `npm install -g clawmaster@%s`\n\n' "$VERSION"
+            printf '### Desktop App (Beta)\n\n'
+            printf 'Download the installer for your platform from the Assets section below.\n\n'
+            printf '| Platform | Files |\n'
+            printf '|---|---|\n'
+            printf '| Linux x64 | `.AppImage`, `.deb`, `.rpm` |\n'
+            printf '| macOS Intel | `.dmg` |\n'
+            printf '| macOS Apple Silicon | `.dmg` |\n'
+            printf '| Windows x64 | `.msi`, `.exe` |\n\n'
+            printf '> **Note:** Desktop builds are in beta. The CLI + Web Console is the recommended install method.\n\n'
+            printf '## Checksums\n\n'
+            printf 'Verify downloads with `SHA256SUMS.txt` attached to this release.\n\n'
+            printf "## What's Changed\n\n"
+            printf '%s\n' "$GENERATED_BODY"
+          } > RELEASE_NOTES.md
 
       - name: Create or update GitHub release
         env:
@@ -416,17 +420,27 @@ jobs:
             fi
           fi
 
+          # Pre-releases must not become the "latest" release on GitHub
+          LATEST_FLAG="--latest"
+          if [ -n "$PRERELEASE_FLAG" ]; then
+            LATEST_FLAG="--latest=false"
+          fi
+
           if gh release view "$TAG" >/dev/null 2>&1; then
+            # Force un-draft so tag re-pushes produce a publicly-visible release
             gh release edit "$TAG" \
               --title "ClawMaster $TAG" \
-              --notes-file RELEASE_NOTES.md
+              --notes-file RELEASE_NOTES.md \
+              --draft=false \
+              $LATEST_FLAG
             gh release upload "$TAG" release-assets/* --clobber
           else
             gh release create "$TAG" release-assets/* \
               --title "ClawMaster $TAG" \
               --notes-file RELEASE_NOTES.md \
               $DRAFT_FLAG \
-              $PRERELEASE_FLAG
+              $PRERELEASE_FLAG \
+              $LATEST_FLAG
           fi
 
       - name: Add workflow summary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -263,7 +263,19 @@ jobs:
             echo "tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Check if version already published
+        id: check_npm
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "clawmaster@$VERSION" version >/dev/null 2>&1; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "clawmaster@$VERSION is already on npm; skipping publish"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish
+        if: steps.check_npm.outputs.skip != 'true'
         run: npm publish --tag ${{ steps.npm_tag.outputs.tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,25 +180,28 @@ jobs:
             exit 1
           fi
 
+          # Use -maxdepth to stay in top-level bundle output dirs (e.g. bundle/msi/,
+          # bundle/deb/). This keeps internal resources (ICU data, npm packages
+          # bundled via .tauri-resources/) out of the release artifacts.
           case "$RUNNER_OS" in
             Linux)
               for root in "${BUNDLE_ROOTS[@]}"; do
-                find "$root" -type f \
-                  \( -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' -o -name '*.sig' -o -name '*.json' \) \
+                find "$root" -maxdepth 3 -type f \
+                  \( -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' -o -name '*.sig' \) \
                   -exec cp '{}' "$ARTIFACT_DIR"/ \;
               done
               ;;
             macOS)
               for root in "${BUNDLE_ROOTS[@]}"; do
-                find "$root" -type f \
-                  \( -name '*.dmg' -o -name '*.app.tar.gz' -o -name '*.sig' -o -name '*.json' \) \
+                find "$root" -maxdepth 3 -type f \
+                  \( -name '*.dmg' -o -name '*.app.tar.gz' -o -name '*.sig' \) \
                   -exec cp '{}' "$ARTIFACT_DIR"/ \;
               done
               ;;
             Windows)
               for root in "${BUNDLE_ROOTS[@]}"; do
-                find "$root" -type f \
-                  \( -name '*.msi' -o -name '*.exe' -o -name '*.zip' -o -name '*.sig' -o -name '*.json' \) \
+                find "$root" -maxdepth 3 -type f \
+                  \( -name '*.msi' -o -name '*.exe' -o -name '*.zip' -o -name '*.sig' \) \
                   -exec cp '{}' "$ARTIFACT_DIR"/ \;
               done
               ;;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,10 +80,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             label: Linux x64
             artifact_name: clawmaster-linux-x64
+            bundles: appimage,deb
           - os: macos-15-intel
             target: x86_64-apple-darwin
             label: macOS Intel
@@ -150,7 +151,7 @@ jobs:
           echo "Normalized tauri.conf.json version to $NUMERIC"
 
       - name: Build Tauri desktop bundles
-        run: npx tauri build --target ${{ matrix.target }}
+        run: npx tauri build --target ${{ matrix.target }} ${{ matrix.bundles && format('--bundles {0}', matrix.bundles) || '' }}
 
       - name: Collect workflow bundle files
         shell: bash
@@ -187,7 +188,7 @@ jobs:
             Linux)
               for root in "${BUNDLE_ROOTS[@]}"; do
                 find "$root" -maxdepth 3 -type f \
-                  \( -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' -o -name '*.sig' \) \
+                  \( -name '*.AppImage' -o -name '*.deb' -o -name '*.sig' \) \
                   -exec cp '{}' "$ARTIFACT_DIR"/ \;
               done
               ;;
@@ -337,7 +338,7 @@ jobs:
           # Only installer bundles — exclude internal JSON (ICU data, package
           # manifests, tsconfig) that gets packaged inside Tauri resources.
           find release-bundles -type f \
-            \( -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' \
+            \( -name '*.AppImage' -o -name '*.deb' \
                -o -name '*.dmg' -o -name '*.app.tar.gz' \
                -o -name '*.msi' -o -name '*.exe' \
                -o -name '*.sig' \) \
@@ -395,7 +396,7 @@ jobs:
             printf 'Download the installer for your platform from the Assets section below.\n\n'
             printf '| Platform | Files |\n'
             printf '|---|---|\n'
-            printf '| Linux x64 | `.AppImage`, `.deb`, `.rpm` |\n'
+            printf '| Linux x64 | `.AppImage`, `.deb` |\n'
             printf '| macOS Intel | `.dmg` |\n'
             printf '| macOS Apple Silicon | `.dmg` |\n'
             printf '| Windows x64 | `.msi`, `.exe` |\n\n'

--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -14,16 +14,21 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            const body = pr.body ?? '';
+            // Normalize CRLF → LF so regexes don't break on Windows-style line endings
+            const body = (pr.body ?? '').replace(/\r\n/g, '\n');
 
-            // "What" section must exist and have meaningful content after the heading
-            const whatMatch = body.match(/##\s*What\s*\n([\s\S]*?)(?=\n##|$)/i);
-            const whatContent = (whatMatch?.[1] ?? '').replace(/<!--[\s\S]*?-->/g, '').trim();
+            // Split the body into sections on Markdown headings (## or ###).
+            // Each section starts with the heading text on its own line.
+            const sections = body.split(/^#{2,}\s+/m).slice(1);
+            const whatSection = sections.find((s) => /^what\b/i.test(s.trim()));
+            const whatContent = whatSection
+              ? whatSection.replace(/^what[^\n]*\n/i, '').replace(/<!--[\s\S]*?-->/g, '').trim()
+              : '';
 
             if (whatContent.length < 20) {
               core.setFailed(
-                'PR description is missing a What section.\n' +
-                'Please fill in ## What with at least one sentence describing what changed.'
+                'PR description is missing a What section with enough detail.\n' +
+                'Please fill in ## What with at least one sentence (20+ chars) describing what changed.'
               );
               return;
             }
@@ -35,6 +40,8 @@ jobs:
                 'Please confirm and delete it before requesting review.'
               );
             }
+
+            core.info(`## What section detected: ${whatContent.length} chars`);
 
             // Nudge: if the PR touches UI modules and the body has no embedded images,
             // suggest adding screenshots. Warning only — never blocks merge.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Download the installer for your platform from [GitHub Releases](https://github.c
 | macOS Apple Silicon | `.dmg` |
 | macOS Intel | `.dmg` |
 | Windows x64 | `.msi`, `.exe` |
-| Linux x64 | `.deb`, `.rpm`, `.AppImage` |
+| Linux x64 | `.deb`, `.AppImage` |
 
 > [!WARNING]
 > Desktop builds are in **beta**. The CLI + Web Console is the recommended and most thoroughly tested install method.

--- a/README_CN.md
+++ b/README_CN.md
@@ -70,7 +70,7 @@ clawmaster doctor            # 检查环境
 | macOS Apple Silicon | `.dmg` |
 | macOS Intel | `.dmg` |
 | Windows x64 | `.msi`、`.exe` |
-| Linux x64 | `.deb`、`.rpm`、`.AppImage` |
+| Linux x64 | `.deb`、`.AppImage` |
 
 > [!WARNING]
 > 桌面版目前处于 **Beta 测试阶段**。推荐使用 CLI + Web 控制台方式，这是经过最充分测试的安装方式。

--- a/README_JP.md
+++ b/README_JP.md
@@ -70,7 +70,7 @@ clawmaster doctor            # 環境を確認
 | macOS Apple Silicon | `.dmg` |
 | macOS Intel | `.dmg` |
 | Windows x64 | `.msi`、`.exe` |
-| Linux x64 | `.deb`、`.rpm`、`.AppImage` |
+| Linux x64 | `.deb`、`.AppImage` |
 
 > [!WARNING]
 > デスクトップ版は現在 **Beta** です。CLI + Web コンソールが最も十分にテストされたインストール方法として推奨されます。


### PR DESCRIPTION
## What

Fix three issues with the v0.3.0-rc.1 release page:

1. **Draft release**: `gh release edit` didn't un-draft existing releases, so tag re-pushes left the release in draft state with an `untagged-*` URL
2. **Garbage JSON assets**: The asset glob `-name '*.json'` pulled in ICU encoding data (`cp936.json`, `big5-added.json`, etc.), `package.json`, `tsconfig.json` from inside Tauri bundles — all showed up as release assets
3. **Broken release notes**: YAML `run: |` indentation leaked into the heredoc, turning every heading into an indented code block. Also `@\${TAG#v}` didn't substitute, so the install command showed literal `${TAG#v}` text

## Why

The v0.3.0-rc.1 release page currently shows as draft with 23 garbage files and malformed markdown. For a public release, this must be clean.

## How

- **Un-draft**: Add `--draft=false` and `--latest=false` (for pre-releases) to `gh release edit`
- **Asset glob**: Remove `*.json` from both per-platform bundle collection and release-assets collection. Add `-maxdepth 3` to stay in top-level bundle output dirs
- **Release notes**: Replace heredoc with `printf` calls so no indentation leaks. Show npm dist-tag (`@rc` or `@latest`) in the copy-paste install command + a second line with the exact version for pinning

Verification: after merge + re-tag, the release page should have only 7 real bundle files + SHA256SUMS.txt, proper markdown headings, and be publicly visible with the "Pre-release" badge.