### PR TITLE
ci: trim Desktop Bundles triggers to release-track only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,15 +1,22 @@
 name: Desktop Bundles
 
 on:
+  # Expensive desktop bundle builds only run on release-track events:
+  #   - push to release/**, hotfix/**  (validate before tagging)
+  #   - tag push v*                   (actual release)
+  #   - PR to main                    (release/hotfix PRs — verify job only)
+  #   - workflow_dispatch             (manual)
+  # Push to main/develop does NOT trigger this workflow. Test Suite (test.yml)
+  # handles TypeScript/tests/build validation on those branches.
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths-ignore:
       - '**.md'
       - 'docs/**'
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/PULL_REQUEST_TEMPLATE.md'
   push:
-    branches: [main, develop, 'release/**', 'hotfix/**']
+    branches: ['release/**', 'hotfix/**']
     tags: ['v*']
     paths-ignore:
       - '**.md'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -425,7 +425,12 @@ Run `dev-browser --help` for the full LLM-oriented API reference.
 
 ### CI
 
-Every push/PR to `develop` or `main`: `npm ci` → TypeScript check → `npm test` → `npm run build`.
-Tags (`v*`) + `main` + manual dispatch: multi-platform Tauri builds (Linux x64, macOS x64/ARM64, Windows x64).
-Draft GitHub releases created on tag pushes; non-tag builds upload artifacts with 7-day retention.
-Release (`release/*`) and hotfix (`hotfix/*`) branches also trigger CI on push and PR.
+**Test Suite** (`test.yml`) runs on every push/PR to `develop`, `main`, `release/**`, `hotfix/**`: TypeScript check → unit tests (546) → package install smoke (Linux/macOS/Windows) → backend integration → Tauri cargo check → E2E smoke.
+
+**Desktop Bundles** (`build.yml`) only runs on release-track events:
+- Push to `release/**` or `hotfix/**` — validates bundles before tagging
+- Push of tag `v*` — produces release artifacts + publishes to npm + creates GitHub release
+- PR to `main` (i.e. release/hotfix PRs) — runs `verify` job for quick validation
+- Manual `workflow_dispatch`
+
+Push to `main`/`develop` does **not** trigger desktop bundle builds — Test Suite covers regression checks, and `tauri-check` (fast `cargo check`) catches Rust compile errors. This keeps the slow multi-platform Tauri builds scoped to actual release work.


### PR DESCRIPTION
## What

Scope the Desktop Bundles workflow to release-track events only. Push to `main`/`develop` no longer triggers the expensive 4-platform Tauri build.

## Why

Every push to develop was running 4 desktop bundles (Linux, Windows, macOS Intel, macOS ARM) — ~20+ minutes of compute per push even though those bundles aren't used anywhere. Bundles are only consumed by GitHub Releases (tag push) and sanity-checked during release branch stabilization.

## How

**Triggers now:**
- Push to `release/**`, `hotfix/**` — validates bundles before tagging
- Push tag `v*` — produces release artifacts + npm publish + GitHub Release
- PR to `main` (which per git-flow is only release/hotfix) — runs `verify` for quick check
- Manual `workflow_dispatch`

**What's still protected on every push to main/develop:**
- Test Suite (`test.yml`): TypeScript check, 546 unit tests, install smoke on all 3 OSes, backend integration, `tauri-check` (fast cargo check for Rust safety), E2E smoke

Rust compile errors get caught by `tauri-check` without the cost of full bundling.