### PR TITLE
ci: gate tests and desktop smoke on PRs into release/** and hotfix/**

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -9,7 +9,7 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/PULL_REQUEST_TEMPLATE.md'
   pull_request:
-    branches: [main]
+    branches: [main, 'release/**', 'hotfix/**']
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/PULL_REQUEST_TEMPLATE.md'
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, 'release/**', 'hotfix/**']
     paths-ignore:
       - '**.md'
       - 'docs/**'


### PR DESCRIPTION
## What
Add \`release/**\` and \`hotfix/**\` to the \`pull_request.branches\` list in \`test.yml\` and \`desktop-e2e.yml\`, so the same CI gates that run on PRs to \`main\`/\`develop\` also run on PRs into release and hotfix branches.

## Why
Today \`test.yml\` and \`desktop-e2e.yml\` trigger on \`pull_request\` only for \`main\` and \`develop\` (test) or \`main\` (desktop smoke). That means PRs targeting \`release/0.3.0\` — including rc stabilization fixes like [#81](https://github.com/openmaster-ai/clawmaster/pull/81) — only get the lightweight \`pr-description-check.yml\` run. Tests only execute on push *after* merge, when failures are more expensive to fix. Adding the release/hotfix branches here closes that gap so rc PRs get the same validation as PRs into \`develop\`.

## Scope
- \`test.yml\` — \`pull_request.branches\` gains \`'release/**', 'hotfix/**'\`
- \`desktop-e2e.yml\` — same
- \`build.yml\` **intentionally skipped** — its PR trigger is already scoped to \`main\` (for the final release→main PR). Desktop bundles are expensive cross-platform builds, and the post-merge \`push: branches: ['release/**', 'hotfix/**']\` trigger already catches bundle failures before tag.

## Target branch
\`release/0.3.0\` — lands first where it's immediately useful for rc.2 stabilization; forward-propagates into \`main\` and \`develop\` via the standard release merges at 0.3.0 GA.

## Test plan
- [x] YAML syntactically valid (two-line changes, same shape as existing entries)
- [ ] After merge, open a trivial follow-up PR into \`release/0.3.0\` and verify \`test.yml\` + \`desktop-e2e.yml\` now run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)