### PR TITLE
test: fix flaky ContentDrafts listHint assertion

### DIFF
--- a/packages/web/src/modules/content-drafts/__tests__/ContentDraftsPage.test.tsx
+++ b/packages/web/src/modules/content-drafts/__tests__/ContentDraftsPage.test.tsx
@@ -94,7 +94,8 @@ describe('ContentDraftsPage', () => {
     )
 
     expect(await screen.findByRole('heading', { name: 'Content Drafts' })).toBeInTheDocument()
-    expect(screen.getByText('Each row shows draft metadata first. Expand a row to read the rendered draft with inline images, then inspect artifact paths only if needed.')).toBeInTheDocument()
+    // listHint renders only after variants load; use findBy to wait for async fetch
+    expect(await screen.findByText('Each row shows draft metadata first. Expand a row to read the rendered draft with inline images, then inspect artifact paths only if needed.')).toBeInTheDocument()
     expect(mockReadContentDraftTextResult).not.toHaveBeenCalled()
 
     fireEvent.click(screen.getByRole('button', { name: /Weekly digest/i }))


### PR DESCRIPTION
## What
Change the \`getByText\` assertion for \`contentDrafts.listHint\` in \`ContentDraftsPage.test.tsx\` to \`findByText\` so the test waits for the async variants fetch to resolve before checking for the hint.

## Why
\`ContentDraftsPage.tsx:648\` renders the listHint only when \`filteredVariants.length > 0\`. The list comes from an async adapter (mocked in the test), so the hint appears a tick after the heading resolves. The sync \`getByText\` call immediately after \`findByRole('heading', ...)\` hit the render window on fast local machines but missed it on slower CI runners — flaked on PR #81's Unit Tests job ([run](https://github.com/openmaster-ai/clawmaster/actions/runs/24827001604/job/72665458427)) while passing 5/5 locally. Not caused by #81; just surfaced there now that release/** PRs run the full test matrix.

## Test plan
- [x] 5/5 consecutive local runs pass with the fix
- [x] Fix is 1 character: \`getByText\` → \`findByText\`, no behavior change

## Target branch
\`release/0.3.0\` — unblocks #81 and any future rc stabilization PR that would otherwise hit this flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)