### PR TITLE
ci(desktop-smoke): populate cache on release/** and hotfix/** pushes

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -2,7 +2,12 @@ name: Desktop Smoke
 
 on:
   push:
-    branches: [main, 'feat/**']
+    # release/** and hotfix/** are included so the desktop-smoke cache gets
+    # populated on the release branch itself after PRs merge. Without this,
+    # the GitHub Actions cache scope for release/0.3.0 stays empty and every
+    # rc PR pays the full cargo-install + npm-install-openclaw cost because
+    # it cannot read caches from the merged PR's feature branch.
+    branches: [main, 'feat/**', 'release/**', 'hotfix/**']
     paths-ignore:
       - '**.md'
       - 'docs/**'


### PR DESCRIPTION
## What
Add \`release/**\` and \`hotfix/**\` to the \`push\` trigger of \`desktop-e2e.yml\` so that merges into those release branches run Desktop Smoke and populate the base-branch GitHub Actions cache scope.

## Why — traced from PR #81
PR #81's Windows Desktop Smoke took 15 minutes even after PR #84 (caching) merged. Cache logs from the run:

\`\`\`
key: openclaw-cli-Windows-2026.4.11
Cache not found for input keys: openclaw-cli-Windows-2026.4.11
...
key: cargo-webdriver-tools-Windows-v1
Cache not found for input keys: cargo-webdriver-tools-Windows-v1
\`\`\`

Root cause is GitHub Actions **cache scoping**: caches are scoped per-branch, and a PR's workflow can only read caches from its own branch scope or its base branch. PR #84 populated caches on branch \`ci/cache-desktop-smoke-installs\`. After PR #84 merged to \`release/0.3.0\`, no \`push\` event fired \`desktop-e2e.yml\` (its \`push\` trigger was \`[main, 'feat/**']\` only), so the \`release/0.3.0\` cache scope stayed empty. PR #81, targeting \`release/0.3.0\`, therefore had nothing to read and paid the full cargo-install + \`npm install -g openclaw\` cost from scratch.

\`test.yml\` already includes \`release/**\` + \`hotfix/**\` in its push trigger — that's why its caches work for rc PRs. This PR brings \`desktop-e2e.yml\` in line.

## Trade-off
Adding \`release/**\` + \`hotfix/**\` to push means Desktop Smoke runs once after every merge to a release branch. Cost is ~5 min per merge (now that caches work). Benefit is every subsequent rc PR hits cache and finishes Windows smoke in ~5 min instead of 13–15. Net win across rc.2 stabilization.

## Test plan
- [ ] Merge this PR. Next push to \`release/0.3.0\` (this merge itself) triggers Desktop Smoke, populates the cache scope.
- [ ] Open a trivial follow-up PR targeting \`release/0.3.0\`. Windows smoke should drop to ~5m with cache hits on all three artifacts (openclaw CLI, tauri-driver, msedgedriver-tool).

## Target branch
\`release/0.3.0\` — pure CI config, one-line change to the push branches list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)