### PR TITLE
chore(release): v0.3.0-rc.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawmaster",
-  "version": "0.3.0-rc.1",
+  "version": "0.3.0-rc.2",
   "description": "龙虾管理大师——OpenClaw 生态的六边形战士",
   "bin": {
     "clawmaster": "./bin/clawmaster.mjs"

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw-manager/backend",
-  "version": "0.3.0-rc.1",
+  "version": "0.3.0-rc.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw-manager/web",
-  "version": "0.3.0-rc.1",
+  "version": "0.3.0-rc.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 description = "A Tauri App"
 authors = ["openmaster-ai"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "ClawMaster",
-  "version": "0.3.0-rc.1",
+  "version": "0.3.0-rc.2",
   "identifier": "ai.openclaw.manager",
   "build": {
     "frontendDist": "../packages/web/dist",


### PR DESCRIPTION
## What

Bump version to `0.3.0-rc.2` across all packages (root, backend, web, Cargo.toml, tauri.conf.json).

## Why

rc.2 bundles UI polish + bug fixes accumulated on `release/0.3.0` since rc.1.

## rc.2 highlights (vs rc.1)

- **fix(setup):** custom-openai-compatible probe for GLM-style URLs — strip `/chat/completions` suffix, add GET /models fallback (#81)
- **feat(setup):** live `/models` catalog for custom-openai-compatible provider (#81)
- **polish(setup/models):** regroup providers into 3 visual tiers — sponsors, featured, compatible-and-local — with per-tier collapse (#85)
- **ci(desktop-smoke):** cache global openclaw install + cargo-installed WebDriver tools; Windows smoke dropped 15m → ~5m (#84, #86)
- **ci:** run full test + desktop-e2e on `release/**` and `hotfix/**` push/PR so rc cuts get the full gate (#86)
- **test:** fix flaky ContentDrafts listHint assertion (#83)

## Next steps after merge

1. Tag `v0.3.0-rc.2` on `release/0.3.0` tip
2. Push tag → triggers desktop bundles + npm `@rc` publish via `build.yml`
3. Verify release assets + `npm install -g clawmaster@rc` smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)