### PR TITLE
ci(release): custom changelog grouped by commit type

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,6 +297,12 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Custom release-notes script walks the full commit range between
+          # the previous v* tag and the current tag via `git describe` + `git
+          # log`, which needs complete history and tags present.
+          fetch-depth: 0
+          fetch-tags: true
 
       - uses: actions/download-artifact@v5
         with:
@@ -365,21 +371,15 @@ jobs:
       - name: Create release notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPOSITORY: ${{ github.repository }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ steps.release_meta.outputs.tag }}
-          TARGET_COMMITISH: ${{ github.sha }}
         run: |
           set -euo pipefail
 
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            "repos/$REPOSITORY/releases/generate-notes" \
-            -f tag_name="$TAG" \
-            -f target_commitish="$TARGET_COMMITISH" \
-            > generated-release-notes.json
-
-          GENERATED_BODY="$(node -e "const fs=require('fs'); const body=JSON.parse(fs.readFileSync('generated-release-notes.json','utf8')).body || ''; process.stdout.write(body.trim());")"
+          # Custom script groups commits by conventional-commit type into
+          # emoji'd buckets. Beats `gh api .../generate-notes` for git-flow
+          # repos where the tagged branch only sees the release-merge commit.
+          GENERATED_BODY="$(node scripts/release-notes.mjs "$TAG")"
 
           VERSION="${TAG#v}"
           NPM_TAG="latest"

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+// Emits a Markdown "What's Changed" section for a tag, grouping commits by
+// conventional-commit type into 4 buckets with emoji. Designed for GitHub
+// releases where `gh api .../releases/generate-notes` falls short because the
+// tagged branch only contains release-merge commits (git-flow pattern).
+//
+// Usage: node scripts/release-notes.mjs <tag>
+// Env:   GH_REPO (owner/repo) — required; GH_TOKEN/GITHUB_TOKEN for PR lookup.
+
+import { execSync } from 'node:child_process'
+
+const tag = process.argv[2]
+if (!tag) {
+  console.error('usage: release-notes.mjs <tag>')
+  process.exit(1)
+}
+
+const repo =
+  process.env.GH_REPO ||
+  execSync('gh repo view --json nameWithOwner --jq .nameWithOwner', { encoding: 'utf8' }).trim()
+
+const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN
+
+let prevTag = ''
+try {
+  prevTag = execSync(`git describe --tags --abbrev=0 --match 'v*' ${tag}^`, {
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'ignore'],
+  }).trim()
+} catch {
+  // No previous tag — this is the first release.
+}
+
+const range = prevTag ? `${prevTag}..${tag}` : tag
+const log = execSync(`git log --no-merges --pretty=format:%H%x09%s ${range}`, {
+  encoding: 'utf8',
+}).trim()
+
+const commits = log
+  .split('\n')
+  .filter(Boolean)
+  .map((line) => {
+    const [sha, ...rest] = line.split('\t')
+    return { sha, subject: rest.join('\t') }
+  })
+
+const BUCKETS = [
+  { id: 'features', title: '### ✨ Features & Polish', types: ['feat', 'polish'] },
+  { id: 'fixes', title: '### 🐛 Fixes', types: ['fix'] },
+  {
+    id: 'ci-tests',
+    title: '### 🔧 CI & Tests',
+    types: ['ci', 'test', 'build', 'perf', 'refactor'],
+  },
+  { id: 'release', title: '### 📦 Release', types: ['chore', 'docs', 'style'] },
+  { id: 'misc', title: '### 📝 Misc', types: [] },
+]
+
+function bucketOf(subject) {
+  const m = subject.match(/^([a-z]+)(?:\([^)]+\))?:/)
+  if (!m) return 'misc'
+  const type = m[1]
+  return BUCKETS.find((b) => b.types.includes(type))?.id ?? 'misc'
+}
+
+async function prFor(sha) {
+  const res = await fetch(`https://api.github.com/repos/${repo}/commits/${sha}/pulls`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  })
+  if (!res.ok) return null
+  const body = await res.json()
+  return Array.isArray(body) && body[0]?.number ? body[0].number : null
+}
+
+const withPr = await Promise.all(
+  commits.map(async (c) => ({ ...c, pr: await prFor(c.sha), bucket: bucketOf(c.subject) })),
+)
+
+const lines = []
+for (const bucket of BUCKETS) {
+  const items = withPr.filter((c) => c.bucket === bucket.id)
+  if (!items.length) continue
+  lines.push(bucket.title, '')
+  for (const c of items) {
+    const prLink = c.pr ? ` ([#${c.pr}](https://github.com/${repo}/pull/${c.pr}))` : ''
+    lines.push(`- ${c.subject}${prLink}`)
+  }
+  lines.push('')
+}
+
+if (prevTag) {
+  lines.push(`**Full Changelog**: https://github.com/${repo}/compare/${prevTag}...${tag}`)
+}
+
+process.stdout.write(lines.join('\n').trim() + '\n')


### PR DESCRIPTION
## What

Replace the built-in \`gh api .../releases/generate-notes\` call in \`build.yml\` with a new \`scripts/release-notes.mjs\` that walks the commit range between the previous \`v*\` tag and the current tag, and groups conventional-commit subjects into 4 emoji'd buckets.

## Why

rc.2's release page shipped with an empty \`What's Changed\` section. \`generate-notes\` lists PRs merged on the tagged branch (main), but git-flow merges land on \`release/**\` first — so main-to-main only sees the single release→main merge PR (#88), not the actual feature PRs (#80–#86).

The new script runs \`git log v<prev>..v<curr>\` which crosses into release-branch history, captures every underlying commit, and looks up each commit's PR via \`GET /repos/:owner/:repo/commits/:sha/pulls\`.

## Buckets

| Emoji | Title | Types |
|---|---|---|
| ✨ | Features & Polish | \`feat\`, \`polish\` |
| 🐛 | Fixes | \`fix\` |
| 🔧 | CI & Tests | \`ci\`, \`test\`, \`build\`, \`perf\`, \`refactor\` |
| 📦 | Release | \`chore\`, \`docs\`, \`style\` |
| 📝 | Misc | anything unmatched (omitted if empty) |

## Verified locally against rc.1 → rc.2

\`\`\`
$ GH_REPO=openmaster-ai/clawmaster GH_TOKEN=\$(gh auth token) \\
    node scripts/release-notes.mjs v0.3.0-rc.2
\`\`\`

Produces the exact format I hand-wrote onto the rc.2 release page after noticing the built-in notes were empty.

## Notes

- \`publish-release\` job now checks out with \`fetch-depth: 0\` + \`fetch-tags: true\` so \`git describe\` + \`git log range\` work.
- Script uses only Node's built-in \`fetch\` + \`execSync\` — no new deps.
- First-release edge case handled: if no previous tag exists, the script lists all commits up to the tag and skips the \"Full Changelog\" link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)