### PR TITLE
Hotfix 0.3.0 wizard skip-flow E2E flake

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -441,6 +441,9 @@ jobs:
           await skipLink.first().click();
           const skipGatewayStep = page.locator('text=网关').or(page.locator('text=Gateway'));
           await skipGatewayStep.first().waitFor({ timeout: 5000 });
+          await page.locator('text=网关已启动').or(page.locator('text=Gateway started')).first()
+            .waitFor({ timeout: 10000 })
+            .catch(() => page.locator('text=已就绪').or(page.locator('text=Ready')).first().waitFor({ timeout: 2000 }));
           const skipEnterBtn = page.locator('text=进入管理大师').or(page.locator('text=Enter ClawMaster'));
           await skipEnterBtn.first().waitFor({ timeout: 5000 });
           await skipEnterBtn.first().click();


### PR DESCRIPTION
## What
- make the wizard E2E skip flow wait for gateway readiness before expecting the final enter action

## Why
- main is blocked from tagging v0.3.0 because the post-merge Test Suite keeps failing in the skip-flow branch of the wizard smoke
- the setup wizard enters the gateway step in a transient checking state before the enter button appears

## How
- keep the existing skip-flow coverage
- update the CI smoke to wait for the gateway-ready state before locating Enter ClawMaster

## Screenshots
- n/a (CI workflow-only hotfix)
