### PR TITLE
Fix release note links and contributor credits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -443,6 +443,20 @@ jobs:
             NPM_TAG="rc"
           fi
 
+          RELEASE_URL="https://github.com/${GH_REPO}/releases/tag/${TAG}"
+          RELEASE_DOWNLOAD_BASE="https://github.com/${GH_REPO}/releases/download/${TAG}"
+          NPM_PACKAGE_URL="https://www.npmjs.com/package/clawmaster/v/${VERSION}"
+          NPM_DIST_URL="https://www.npmjs.com/package/clawmaster?activeTab=versions"
+
+          # Build direct asset URLs deterministically from the release tag.
+          linux_appimage_url="${RELEASE_DOWNLOAD_BASE}/ClawMaster_${VERSION}_amd64.AppImage"
+          linux_deb_url="${RELEASE_DOWNLOAD_BASE}/ClawMaster_${VERSION}_amd64.deb"
+          macos_intel_url="${RELEASE_DOWNLOAD_BASE}/ClawMaster_${VERSION}_x64.dmg"
+          macos_arm64_url="${RELEASE_DOWNLOAD_BASE}/ClawMaster_${VERSION}_aarch64.dmg"
+          windows_msi_url="${RELEASE_DOWNLOAD_BASE}/ClawMaster_${VERSION}_x64_en-US.msi"
+          windows_exe_url="${RELEASE_DOWNLOAD_BASE}/ClawMaster_${VERSION}_x64-setup.exe"
+          checksums_url="${RELEASE_DOWNLOAD_BASE}/SHA256SUMS.txt"
+
           # Use printf instead of heredoc because YAML's `run: |` indentation
           # leaks into the heredoc content — turning every heading into an
           # indented code block in the rendered markdown.
@@ -450,22 +464,23 @@ jobs:
             printf '## Install\n\n'
             printf '### CLI + Web Console (Recommended)\n\n'
             printf '```bash\n'
-            printf 'npm install -g clawmaster@%s\n' "$NPM_TAG"
+            printf 'npm install -g clawmaster\n'
             printf 'clawmaster\n'
             printf '```\n\n'
-            printf 'Open http://localhost:16223 — the setup wizard guides you through OpenClaw engine detection and LLM provider configuration.\n\n'
+            printf '`clawmaster` starts the local service and opens the landing page in your browser by default.\n\n'
+            printf 'If the browser does not open automatically, use the backup local address: http://localhost:16223\n\n'
+            printf -- '- npm package: [%s](%s)\n' "clawmaster@${VERSION}" "$NPM_PACKAGE_URL"
+            printf -- '- all published versions: [%s](%s)\n\n' "npm versions" "$NPM_DIST_URL"
             printf '> To pin this exact version: `npm install -g clawmaster@%s`\n\n' "$VERSION"
             printf '### Desktop App (Beta)\n\n'
-            printf 'Download the installer for your platform from the Assets section below.\n\n'
-            printf '| Platform | Files |\n'
+            printf 'Direct downloads for this release. Checksums: [`SHA256SUMS.txt`](%s)\n\n' "$checksums_url"
+            printf '| Platform | Downloads |\n'
             printf '|---|---|\n'
-            printf '| Linux x64 | `.AppImage`, `.deb` |\n'
-            printf '| macOS Intel | `.dmg` |\n'
-            printf '| macOS Apple Silicon | `.dmg` |\n'
-            printf '| Windows x64 | `.msi`, `.exe` |\n\n'
-            printf '> **Note:** Desktop builds are in beta. The CLI + Web Console is the recommended install method.\n\n'
-            printf '## Checksums\n\n'
-            printf 'Verify downloads with `SHA256SUMS.txt` attached to this release.\n\n'
+            printf '| Linux x64 | [AppImage](%s) · [deb](%s) |\n' "$linux_appimage_url" "$linux_deb_url"
+            printf '| macOS Intel | [dmg](%s) |\n' "$macos_intel_url"
+            printf '| macOS Apple Silicon | [dmg](%s) |\n' "$macos_arm64_url"
+            printf '| Windows x64 | [msi](%s) · [exe](%s) |\n\n' "$windows_msi_url" "$windows_exe_url"
+            printf '> Desktop builds are in beta. The CLI + Web Console is the recommended install method.\n\n'
             printf "## What's Changed\n\n"
             printf '%s\n' "$GENERATED_BODY"
           } > RELEASE_NOTES.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -441,6 +441,9 @@ jobs:
           await skipLink.first().click();
           const skipGatewayStep = page.locator('text=网关').or(page.locator('text=Gateway'));
           await skipGatewayStep.first().waitFor({ timeout: 5000 });
+          await page.locator('text=网关已启动').or(page.locator('text=Gateway started')).first()
+            .waitFor({ timeout: 10000 })
+            .catch(() => page.locator('text=已就绪').or(page.locator('text=Ready')).first().waitFor({ timeout: 2000 }));
           const skipEnterBtn = page.locator('text=进入管理大师').or(page.locator('text=Enter ClawMaster'));
           await skipEnterBtn.first().waitFor({ timeout: 5000 });
           await skipEnterBtn.first().click();

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
     "prepack": "npm run build:backend && npm run build",
-    "test:cli": "node --test bin/*.test.mjs tests/desktop/harness.unit.test.mjs",
+    "test:cli": "node --test bin/*.test.mjs scripts/*.test.mjs tests/desktop/harness.unit.test.mjs",
     "test:plugins": "npx tsx --test plugins/memory-clawmaster-powermem/*.test.ts",
     "test:desktop": "node --test tests/desktop/smoke.test.mjs",
     "test:wizard-smoke": "node tests/install/wizard-install-smoke.mjs",

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -2,96 +2,364 @@
 // Emits a Markdown "What's Changed" section for a tag, grouping user-facing
 // conventional commits into a few release-note buckets. CI / release
 // housekeeping and unprefixed commits are intentionally excluded. Designed for GitHub
-// releases where `gh api .../releases/generate-notes` falls short because the
-// tagged branch only contains release-merge commits (git-flow pattern).
+// releases where git-flow tags land on merge commits and the release notes should
+// cover the full release window, not just the nearest preceding tag.
 //
 // Usage: node scripts/release-notes.mjs <tag>
 // Env:   GH_REPO (owner/repo) — required; GH_TOKEN/GITHUB_TOKEN for PR lookup.
 
-import { execSync } from 'node:child_process'
+import { execFileSync, execSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
 
-const tag = process.argv[2]
-if (!tag) {
-  console.error('usage: release-notes.mjs <tag>')
-  process.exit(1)
-}
-
-const repo =
-  process.env.GH_REPO ||
-  execSync('gh repo view --json nameWithOwner --jq .nameWithOwner', { encoding: 'utf8' }).trim()
-
-const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN
-
-let prevTag = ''
-try {
-  prevTag = execSync(`git describe --tags --abbrev=0 --match 'v*' ${tag}^`, {
-    encoding: 'utf8',
-    stdio: ['pipe', 'pipe', 'ignore'],
-  }).trim()
-} catch {
-  // No previous tag — this is the first release.
-}
-
-const range = prevTag ? `${prevTag}..${tag}` : tag
-const log = execSync(`git log --no-merges --pretty=format:%H%x09%s ${range}`, {
-  encoding: 'utf8',
-}).trim()
-
-const commits = log
-  .split('\n')
-  .filter(Boolean)
-  .map((line) => {
-    const [sha, ...rest] = line.split('\t')
-    return { sha, subject: rest.join('\t') }
-  })
-
-const BUCKETS = [
-  { id: 'features', title: '### ✨ Features & Polish', types: ['feat', 'polish'] },
-  { id: 'fixes', title: '### 🐛 Fixes', types: ['fix'] },
-  { id: 'misc', title: '### 📝 Misc', types: [] },
+export const BUCKETS = [
+  { id: 'features', title: 'Features & Polish', emoji: '✨', types: ['feat', 'polish'] },
+  { id: 'fixes', title: 'Fixes', emoji: '🐛', types: ['fix'] },
+  { id: 'misc', title: 'Misc', emoji: '📝', types: [] },
 ]
 
 const EXCLUDED_TYPES = new Set(['ci', 'test', 'build', 'perf', 'refactor', 'chore', 'docs', 'style'])
+const PRE_RELEASE_RE = /-(rc|beta|alpha)(?:\.\d+)?$/i
+const STABLE_TAG_RE = /^v\d+\.\d+\.\d+$/
 
-function bucketOf(subject) {
-  const m = subject.match(/^([a-z]+)(?:\([^)]+\))?:/)
-  if (!m) return null
-  const type = m[1]
-  if (EXCLUDED_TYPES.has(type)) return null
-  return BUCKETS.find((b) => b.types.includes(type))?.id ?? 'misc'
+function runGit(command, options = {}) {
+  return execSync(command, {
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'ignore'],
+    ...options,
+  }).trim()
 }
 
-async function prFor(sha) {
-  const res = await fetch(`https://api.github.com/repos/${repo}/commits/${sha}/pulls`, {
-    headers: {
-      Accept: 'application/vnd.github+json',
-      'X-GitHub-Api-Version': '2022-11-28',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-  })
-  if (!res.ok) return null
-  const body = await res.json()
-  return Array.isArray(body) && body[0]?.number ? body[0].number : null
+export function parseRemoteTags(rawRefs) {
+  return rawRefs
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      const parts = line.trim().split(/\s+/)
+      return parts[1] || ''
+    })
+    .filter((ref) => ref.startsWith('refs/tags/'))
+    .map((ref) => ref.replace(/^refs\/tags\//, '').replace(/\^\{\}$/, ''))
+    .filter(Boolean)
 }
 
-const withPr = await Promise.all(
-  commits.map(async (c) => ({ ...c, pr: await prFor(c.sha), bucket: bucketOf(c.subject) })),
-)
-
-const lines = []
-for (const bucket of BUCKETS) {
-  const items = withPr.filter((c) => c.bucket === bucket.id)
-  if (!items.length) continue
-  lines.push(bucket.title, '')
-  for (const c of items) {
-    const prLink = c.pr ? ` ([#${c.pr}](https://github.com/${repo}/pull/${c.pr}))` : ''
-    lines.push(`- ${c.subject}${prLink}`)
+export function parseTagVersion(tag) {
+  const match = tag.match(/^v(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/)
+  if (!match) return null
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ?? '',
   }
-  lines.push('')
 }
 
-if (prevTag) {
-  lines.push(`**Full Changelog**: https://github.com/${repo}/compare/${prevTag}...${tag}`)
+function compareIdentifiers(a, b) {
+  const aIsNumeric = /^\d+$/.test(a)
+  const bIsNumeric = /^\d+$/.test(b)
+  if (aIsNumeric && bIsNumeric) return Number(a) - Number(b)
+  if (aIsNumeric) return -1
+  if (bIsNumeric) return 1
+  return a.localeCompare(b)
 }
 
-process.stdout.write(lines.join('\n').trim() + '\n')
+export function compareTagVersions(leftTag, rightTag) {
+  const left = parseTagVersion(leftTag)
+  const right = parseTagVersion(rightTag)
+  if (!left || !right) return leftTag.localeCompare(rightTag)
+  for (const key of ['major', 'minor', 'patch']) {
+    if (left[key] !== right[key]) return left[key] - right[key]
+  }
+  if (!left.prerelease && !right.prerelease) return 0
+  if (!left.prerelease) return 1
+  if (!right.prerelease) return -1
+  const leftParts = left.prerelease.split('.')
+  const rightParts = right.prerelease.split('.')
+  const max = Math.max(leftParts.length, rightParts.length)
+  for (let i = 0; i < max; i += 1) {
+    if (leftParts[i] == null) return -1
+    if (rightParts[i] == null) return 1
+    const cmp = compareIdentifiers(leftParts[i], rightParts[i])
+    if (cmp !== 0) return cmp
+  }
+  return 0
+}
+
+export function isStableReleaseTag(tag) {
+  return STABLE_TAG_RE.test(tag)
+}
+
+export function bucketOf(subject) {
+  const match = subject.match(/^([a-z]+)(?:\([^)]+\))?:/)
+  if (!match) return null
+  const type = match[1]
+  if (EXCLUDED_TYPES.has(type)) return null
+  return BUCKETS.find((bucket) => bucket.types.includes(type))?.id ?? 'misc'
+}
+
+export function parseGitLog(rawLog) {
+  return rawLog
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      const [sha, authorName, authorEmail, ...rest] = line.split('\t')
+      return {
+        sha,
+        authorName,
+        authorEmail,
+        subject: rest.join('\t'),
+      }
+    })
+}
+
+export function selectReleaseBaseTag({ tag, previousAncestorTag = '', allTags = [] }) {
+  if (!isStableReleaseTag(tag)) return previousAncestorTag
+  const currentVersion = parseTagVersion(tag)
+  if (!currentVersion) return previousAncestorTag
+  const matchingTags = allTags
+    .filter(Boolean)
+    .sort(compareTagVersions)
+  const previousStable = matchingTags
+    .filter((candidate) => candidate !== tag && isStableReleaseTag(candidate))
+    .filter((candidate) => compareTagVersions(candidate, tag) < 0)
+    .at(-1)
+  const firstTag = matchingTags.at(0) || ''
+  return previousStable || firstTag || previousAncestorTag
+}
+
+function normalizeIdentityPart(value) {
+  return value.trim().toLowerCase()
+}
+
+function addIdentityKeys(target, contributor) {
+  if (contributor.login) target.add(`login:${normalizeIdentityPart(contributor.login)}`)
+  if (contributor.authorEmail) target.add(`email:${normalizeIdentityPart(contributor.authorEmail)}`)
+  if (contributor.authorName) target.add(`name:${normalizeIdentityPart(contributor.authorName)}`)
+}
+
+function contributorIdentityKeys(contributor) {
+  const keys = new Set()
+  addIdentityKeys(keys, contributor)
+  return keys
+}
+
+function isBotContributor({ login, authorName, authorEmail }) {
+  const values = [login, authorName, authorEmail].filter(Boolean).map((value) => value.toLowerCase())
+  return values.some((value) => value.includes('[bot]') || value.endsWith('bot') || value.includes('bot@'))
+}
+
+export function displayContributor(contributor) {
+  if (contributor.login) {
+    const avatar = contributor.avatarUrl ? `<img src="${contributor.avatarUrl}" alt="@${contributor.login}" width="20" height="20"> ` : ''
+    return `${avatar}[@${contributor.login}](https://github.com/${contributor.login})`
+  }
+  return contributor.authorName || contributor.authorEmail
+}
+
+export function joinHumanList(values) {
+  if (values.length === 0) return ''
+  if (values.length === 1) return values[0]
+  if (values.length === 2) return `${values[0]} and ${values[1]}`
+  return `${values.slice(0, -1).join(', ')}, and ${values.at(-1)}`
+}
+
+export function summarizeContributors(commits, priorContributorKeys) {
+  const contributors = []
+  for (const commit of commits) {
+    if (isBotContributor(commit)) continue
+    const candidate = {
+      login: commit.login || '',
+      authorName: commit.authorName || '',
+      authorEmail: commit.authorEmail || '',
+    }
+    const candidateKeys = contributorIdentityKeys(candidate)
+    const existing = contributors.find((entry) => {
+      const entryKeys = contributorIdentityKeys(entry)
+      return [...candidateKeys].some((key) => entryKeys.has(key))
+    })
+    if (!existing) {
+      contributors.push(candidate)
+    } else {
+      if (!existing.login && candidate.login) existing.login = candidate.login
+      if (!existing.authorName && candidate.authorName) existing.authorName = candidate.authorName
+      if (!existing.authorEmail && candidate.authorEmail) existing.authorEmail = candidate.authorEmail
+    }
+  }
+
+  return contributors
+    .map((contributor) => {
+      const keys = contributorIdentityKeys(contributor)
+      const firstTime = ![...keys].some((key) => priorContributorKeys.has(key))
+      return { ...contributor, firstTime }
+    })
+    .sort((left, right) => displayContributor(left).localeCompare(displayContributor(right)))
+}
+
+export function buildReleaseNotesBody({ repo, tag, baseTag, commits, contributors }) {
+  const lines = []
+
+  for (const bucket of BUCKETS) {
+    const items = commits.filter((commit) => commit.bucket === bucket.id)
+    if (!items.length) continue
+    lines.push(`### ${bucket.emoji} ${bucket.title}`, '')
+    lines.push(`Summary: ${items.length} ${items.length === 1 ? 'change' : 'changes'} shipped in this area.`)
+    lines.push('')
+    lines.push('<details>')
+    lines.push(`<summary>Show ${bucket.title.toLowerCase()}</summary>`, '')
+    for (const commit of items) {
+      const hasInlinePrRef = commit.pr ? new RegExp(`(^|[^\\w])#${commit.pr}(?!\\d)`).test(commit.subject) : false
+      const prLink = commit.pr && !hasInlinePrRef ? ` ([#${commit.pr}](https://github.com/${repo}/pull/${commit.pr}))` : ''
+      const authorLink = commit.login ? ` by [@${commit.login}](https://github.com/${commit.login})` : ''
+      lines.push(`- ${commit.subject}${authorLink}${prLink}`)
+    }
+    lines.push('', '</details>', '')
+  }
+
+  if (contributors.length) {
+    const contributorLinks = contributors.map(displayContributor)
+    const firstTimers = contributors.filter((contributor) => contributor.firstTime).map(displayContributor)
+    lines.push('### 🙌 Contributors', '')
+    lines.push(`Thanks ${joinHumanList(contributorLinks)} for the commits that shipped in this release.`)
+    if (firstTimers.length === 1) {
+      lines.push(`Welcome to our first-time contributor ${firstTimers[0]}!`)
+    } else if (firstTimers.length > 1) {
+      lines.push(`Welcome to our first-time contributors ${joinHumanList(firstTimers)}!`)
+    }
+    lines.push('')
+  }
+
+  if (baseTag) {
+    lines.push(`**Full Changelog**: https://github.com/${repo}/compare/${baseTag}...${tag}`)
+  }
+
+  return lines.join('\n').trim() + '\n'
+}
+
+async function fetchJson(url, token, accept = 'application/vnd.github+json') {
+  const pathname = new URL(url).pathname.replace(/^\/+/, '')
+  try {
+    const ghArgs = ['api', pathname, '-H', `Accept: ${accept}`, '-H', 'X-GitHub-Api-Version: 2022-11-28']
+    if (token) ghArgs.push('-H', `Authorization: Bearer ${token}`)
+    const output = execFileSync('gh', ghArgs, {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim()
+    return output ? JSON.parse(output) : null
+  } catch {
+    // Fall through to fetch fallback below.
+  }
+  try {
+    const response = await fetch(url, {
+      headers: {
+        Accept: accept,
+        'X-GitHub-Api-Version': '2022-11-28',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    })
+    if (response.ok) return response.json()
+  } catch {
+    // ignore
+  }
+  return null
+}
+
+export function selectGithubIdentity({ commitAuthor = null, commitCommitter = null, pullAuthor = null }) {
+  const candidate = commitAuthor || commitCommitter || pullAuthor || null
+  return {
+    login: candidate?.login || '',
+    avatarUrl: candidate?.avatar_url || '',
+  }
+}
+
+async function resolveCommitMeta({ repo, sha, token }) {
+  const [commitBody, pullBody] = await Promise.all([
+    fetchJson(`https://api.github.com/repos/${repo}/commits/${sha}`, token),
+    fetchJson(`https://api.github.com/repos/${repo}/commits/${sha}/pulls`, token),
+  ])
+  const firstPull = Array.isArray(pullBody) ? pullBody[0] ?? null : null
+  const identity = selectGithubIdentity({
+    commitAuthor: commitBody?.author ?? null,
+    commitCommitter: commitBody?.committer ?? null,
+    pullAuthor: firstPull?.user ?? null,
+  })
+  return {
+    ...identity,
+    pr: firstPull?.number || null,
+  }
+}
+
+function loadPriorContributorKeys(baseTag) {
+  if (!baseTag) return new Set()
+  const raw = runGit(`git log --no-merges --pretty=format:%an%x09%ae ${baseTag}`)
+  const keys = new Set()
+  for (const line of raw.split('\n').filter(Boolean)) {
+    const [authorName = '', authorEmail = ''] = line.split('\t')
+    if (authorName) keys.add(`name:${normalizeIdentityPart(authorName)}`)
+    if (authorEmail) keys.add(`email:${normalizeIdentityPart(authorEmail)}`)
+  }
+  return keys
+}
+
+export async function generateReleaseNotes(tag, env = process.env) {
+  const repo =
+    env.GH_REPO ||
+    runGit('gh repo view --json nameWithOwner --jq .nameWithOwner')
+  const token = env.GH_TOKEN || env.GITHUB_TOKEN || ''
+
+  let previousAncestorTag = ''
+  try {
+    previousAncestorTag = runGit(`git describe --tags --abbrev=0 --match 'v*' ${tag}^`)
+  } catch {
+    previousAncestorTag = ''
+  }
+
+  let allTags = []
+  try {
+    const rawRemoteTags = runGit(`git ls-remote --tags origin 'v*'`)
+    allTags = [...new Set(parseRemoteTags(rawRemoteTags))]
+  } catch {
+    allTags = []
+  }
+
+  const baseTag = selectReleaseBaseTag({ tag, previousAncestorTag, allTags })
+  const range = baseTag ? `${baseTag}..${tag}` : tag
+  const rawLog = runGit(`git log --no-merges --pretty=format:%H%x09%an%x09%ae%x09%s ${range}`)
+  const commits = parseGitLog(rawLog)
+
+  const enrichedCommits = await Promise.all(
+    commits.map(async (commit) => {
+      const meta = await resolveCommitMeta({ repo, sha: commit.sha, token })
+      return {
+        ...commit,
+        ...meta,
+        bucket: bucketOf(commit.subject),
+      }
+    }),
+  )
+
+  const priorContributorKeys = loadPriorContributorKeys(baseTag)
+  const contributors = summarizeContributors(enrichedCommits, priorContributorKeys)
+  const changelogCommits = enrichedCommits.filter((commit) => commit.bucket)
+
+  return buildReleaseNotesBody({
+    repo,
+    tag,
+    baseTag,
+    commits: changelogCommits,
+    contributors,
+  })
+}
+
+async function main() {
+  const tag = process.argv[2]
+  if (!tag) {
+    console.error('usage: release-notes.mjs <tag>')
+    process.exit(1)
+  }
+
+  const notes = await generateReleaseNotes(tag)
+  process.stdout.write(notes)
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main()
+}

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -1,0 +1,259 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  buildReleaseNotesBody,
+  displayContributor,
+  joinHumanList,
+  parseRemoteTags,
+  selectGithubIdentity,
+  selectReleaseBaseTag,
+  summarizeContributors,
+} from './release-notes.mjs'
+
+test('parseRemoteTags uses remote tags only and strips peeled refs', () => {
+  const tags = parseRemoteTags(`
+abc123\trefs/tags/v0.2.0
+def456\trefs/tags/v0.2.0^{}
+789abc\trefs/tags/v0.3.0-rc.1
+`)
+
+  assert.deepEqual(tags, ['v0.2.0', 'v0.2.0', 'v0.3.0-rc.1'])
+})
+
+test('selectReleaseBaseTag uses the previous official release for official tags', () => {
+  const baseTag = selectReleaseBaseTag({
+    tag: 'v0.3.0',
+    previousAncestorTag: 'v0.3.0-rc.3',
+    allTags: ['v0.2.0', 'v0.3.0-rc.1', 'v0.3.0-rc.2', 'v0.3.0-rc.3', 'v0.3.0'],
+  })
+
+  assert.equal(baseTag, 'v0.2.0')
+})
+
+test('selectReleaseBaseTag falls back to the first tag when no prior official release exists', () => {
+  const baseTag = selectReleaseBaseTag({
+    tag: 'v0.3.0',
+    previousAncestorTag: 'v0.3.0-rc.3',
+    allTags: ['v0.3.0-rc.1', 'v0.3.0-rc.2', 'v0.3.0-rc.3', 'v0.3.0'],
+  })
+
+  assert.equal(baseTag, 'v0.3.0-rc.1')
+})
+
+test('selectReleaseBaseTag keeps the nearest previous tag for prereleases', () => {
+  const baseTag = selectReleaseBaseTag({
+    tag: 'v0.3.0-rc.3',
+    previousAncestorTag: 'v0.3.0-rc.2',
+    allTags: ['v0.2.0', 'v0.3.0-rc.1', 'v0.3.0-rc.2', 'v0.3.0-rc.3'],
+  })
+
+  assert.equal(baseTag, 'v0.3.0-rc.2')
+})
+
+test('summarizeContributors welcomes only first-time human contributors', () => {
+  const contributors = summarizeContributors(
+    [
+      {
+        login: 'repeat-dev',
+        authorName: 'Repeat Dev',
+        authorEmail: 'repeat@example.com',
+      },
+      {
+        login: 'new-dev',
+        authorName: 'New Dev',
+        authorEmail: 'new@example.com',
+      },
+      {
+        login: 'github-actions[bot]',
+        authorName: 'github-actions[bot]',
+        authorEmail: '41898282+github-actions[bot]@users.noreply.github.com',
+      },
+    ],
+    new Set(['email:repeat@example.com']),
+  )
+
+  assert.deepEqual(
+    contributors.map((entry) => ({ login: entry.login, firstTime: entry.firstTime })),
+    [
+      { login: 'new-dev', firstTime: true },
+      { login: 'repeat-dev', firstTime: false },
+    ],
+  )
+})
+
+test('summarizeContributors merges the same contributor across name, email, and login variants', () => {
+  const contributors = summarizeContributors(
+    [
+      {
+        login: '',
+        authorName: 'Haili Zhang',
+        authorEmail: 'haili@example.com',
+      },
+      {
+        login: 'haili',
+        authorName: 'Haili Zhang',
+        authorEmail: '',
+      },
+      {
+        login: '',
+        authorName: '',
+        authorEmail: 'haili@example.com',
+      },
+    ],
+    new Set(['email:haili@example.com']),
+  )
+
+  assert.equal(contributors.length, 1)
+  assert.deepEqual(contributors[0], {
+    login: 'haili',
+    authorName: 'Haili Zhang',
+    authorEmail: 'haili@example.com',
+    firstTime: false,
+  })
+})
+
+test('buildReleaseNotesBody includes contributor thanks, first-time welcome, and release compare link', () => {
+  const body = buildReleaseNotesBody({
+    repo: 'openmaster-ai/clawmaster',
+    tag: 'v0.3.0',
+    baseTag: 'v0.2.0',
+    commits: [
+      {
+        subject: 'feat(models): improve default provider tiers',
+        login: 'alice',
+        pr: 101,
+        bucket: 'features',
+      },
+      {
+        subject: 'fix(setup): wait for gateway readiness in skip flow',
+        login: 'bob',
+        pr: 102,
+        bucket: 'fixes',
+      },
+    ],
+    contributors: [
+      {
+        login: 'alice',
+        authorName: 'Alice',
+        authorEmail: 'alice@example.com',
+        avatarUrl: 'https://avatars.example/alice.png',
+        firstTime: false,
+      },
+      {
+        login: 'bob',
+        authorName: 'Bob',
+        authorEmail: 'bob@example.com',
+        avatarUrl: 'https://avatars.example/bob.png',
+        firstTime: true,
+      },
+    ],
+  })
+
+  assert.match(body, /### ✨ Features & Polish/)
+  assert.match(body, /### 🐛 Fixes/)
+  assert.match(body, /Summary: 1 change shipped in this area\./)
+  assert.match(body, /<details>/)
+  assert.match(body, /<summary>Show features & polish<\/summary>/)
+  assert.match(body, /feat\(models\): improve default provider tiers by \[@alice\]\(https:\/\/github\.com\/alice\) \(\[#101\]/)
+  assert.match(body, /fix\(setup\): wait for gateway readiness in skip flow by \[@bob\]\(https:\/\/github\.com\/bob\) \(\[#102\]/)
+  assert.match(body, /Thanks <img src="https:\/\/avatars\.example\/alice\.png".*\[@alice\].*<img src="https:\/\/avatars\.example\/bob\.png".*\[@bob\].*for the commits that shipped in this release\./)
+  assert.match(body, /Welcome to our first-time contributor <img src="https:\/\/avatars\.example\/bob\.png".*\[@bob\]/)
+  assert.match(body, /compare\/v0\.2\.0\.\.\.v0\.3\.0/)
+})
+
+test('joinHumanList formats short lists naturally', () => {
+  assert.equal(joinHumanList([]), '')
+  assert.equal(joinHumanList(['A']), 'A')
+  assert.equal(joinHumanList(['A', 'B']), 'A and B')
+  assert.equal(joinHumanList(['A', 'B', 'C']), 'A, B, and C')
+})
+
+test('displayContributor prefers GitHub handle and avatar when available', () => {
+  const rendered = displayContributor({
+    login: 'alice',
+    authorName: 'Alice',
+    authorEmail: 'alice@example.com',
+    avatarUrl: 'https://avatars.example/alice.png',
+  })
+
+  assert.equal(
+    rendered,
+    '<img src="https://avatars.example/alice.png" alt="@alice" width="20" height="20"> [@alice](https://github.com/alice)',
+  )
+})
+
+test('selectGithubIdentity falls back from author to committer to PR author', () => {
+  assert.deepEqual(
+    selectGithubIdentity({
+      commitAuthor: null,
+      commitCommitter: { login: 'committer-user', avatar_url: 'https://avatars.example/committer.png' },
+      pullAuthor: { login: 'pr-user', avatar_url: 'https://avatars.example/pr.png' },
+    }),
+    {
+      login: 'committer-user',
+      avatarUrl: 'https://avatars.example/committer.png',
+    },
+  )
+
+  assert.deepEqual(
+    selectGithubIdentity({
+      commitAuthor: null,
+      commitCommitter: null,
+      pullAuthor: { login: 'pr-user', avatar_url: 'https://avatars.example/pr.png' },
+    }),
+    {
+      login: 'pr-user',
+      avatarUrl: 'https://avatars.example/pr.png',
+    },
+  )
+})
+
+test('buildReleaseNotesBody keeps GitHub handles visible in commit lines and contributor thanks', () => {
+  const body = buildReleaseNotesBody({
+    repo: 'openmaster-ai/clawmaster',
+    tag: 'v0.3.0',
+    baseTag: 'v0.2.0',
+    commits: [
+      {
+        subject: 'feat(setup): require gateway check before finishing onboarding',
+        login: 'webup',
+        pr: 93,
+        bucket: 'features',
+      },
+    ],
+    contributors: [
+      {
+        login: 'webup',
+        authorName: 'Haili Zhang',
+        authorEmail: 'haili.zhang@outlook.com',
+        avatarUrl: 'https://avatars.example/webup.png',
+        firstTime: false,
+      },
+    ],
+  })
+
+  assert.match(body, /by \[@webup\]\(https:\/\/github\.com\/webup\)/)
+  assert.match(body, /Thanks <img src="https:\/\/avatars\.example\/webup\.png".*\[@webup\]\(https:\/\/github\.com\/webup\)/)
+  assert.doesNotMatch(body, /Thanks Haili Zhang/)
+})
+
+test('buildReleaseNotesBody does not append a duplicate PR link when subject already includes it', () => {
+  const body = buildReleaseNotesBody({
+    repo: 'openmaster-ai/clawmaster',
+    tag: 'v0.3.0',
+    baseTag: 'v0.2.0',
+    commits: [
+      {
+        subject: 'feat: add content drafts viewer (#67)',
+        login: 'webup',
+        pr: 67,
+        bucket: 'features',
+      },
+    ],
+    contributors: [],
+  })
+
+  assert.match(body, /feat: add content drafts viewer \(#67\) by \[@webup\]/)
+  assert.doesNotMatch(body, /\(\[#67\]\(https:\/\/github\.com\/openmaster-ai\/clawmaster\/pull\/67\)\)/)
+})


### PR DESCRIPTION
## What
- improve release notes for official releases so compare links use remote tags and fall back correctly
- show GitHub handles in contributor credits and avoid duplicate PR references in changelog items
- make install/download sections more compact with direct npm and desktop asset links
- add script-level tests for tag parsing, contributor formatting, and duplicate PR suppression

## Why
The published release notes were using inconsistent compare bases, contributor names instead of GitHub handles, and duplicated PR links in some items. The install section was also more verbose than necessary.

## How
- update `scripts/release-notes.mjs` to resolve release windows from remote tags only and improve contributor/PR formatting
- extend `scripts/release-notes.test.mjs` and wire it into `test:cli`
- update the release body template in `.github/workflows/build.yml`

Closes #97