### PR TITLE
Add Baidu Qianfan Coding Plan provider

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,8 @@ Before opening a provider PR:
 
 - Open or link an issue that identifies the provider, API docs, default base URL, API-key page, supported model IDs, and whether the API is native OpenAI-compatible.
 - Confirm the OpenClaw runtime provider id. Use that id in ClawMaster model refs (`provider/model`) unless there is already a documented alias.
+- If the vendor docs include an OpenClaw config snippet, copy the exact provider id, `baseUrl`, `api` mode, and default model into the issue before coding.
+- Test credentials may be used for local smoke checks, but never commit real keys, screenshots that reveal keys, terminal logs containing keys, or `.env` files.
 - Do not add dependencies for provider integration. Provider setup should use existing adapters, fetch helpers, and config writers.
 
 Provider UI source of truth:
@@ -71,12 +73,14 @@ Live model catalogs:
 - Add the provider default base URL to both `packages/web/src/shared/providerCatalog.ts` and `packages/backend/src/services/providerCatalogService.ts` when the Models page should fetch `/models` in desktop and web modes.
 - Keep catalog allowlists strict. Non-custom providers must only accept their documented host, protocol, port, and base path. The custom OpenAI-compatible provider is the only path that may accept arbitrary public hosts.
 - Add response filtering when a provider returns embeddings, image models, OCR models, moderation models, or other non-chat entries in the same catalog.
+- If `/models` returns a broad catalog or omits a documented default alias, keep the documented fallback `models` list in `PROVIDERS` and filter the live catalog to the provider's intended capability. For example, coding-plan providers should not surface unrelated image, OCR, embedding, or generic chat entries.
 - Keep frontend and backend catalog behavior equivalent; the backend service powers web mode, while the frontend helper powers Tauri mode.
 
 Validation and persistence:
 
 - Provider key validation is implemented in `packages/web/src/modules/setup/adapters.ts`.
 - OpenAI-compatible providers should work through the existing chat/completions probe and `/models` fallback. Do not add provider-specific HTTP code unless the provider is not compatible with the common flow.
+- Smoke-test the documented default model with `POST <baseUrl>/chat/completions` and, when catalog support is enabled, `GET <baseUrl>/models`. Record only status and sanitized findings in the issue or PR.
 - Saved provider config should include `apiKey`, `baseUrl`, `api` when needed, and the static fallback `models` list. The Models page uses that saved list when live catalog discovery is unavailable.
 - Default model refs must use the OpenClaw runtime provider id, for example `zai/glm-5.1`.
 
@@ -152,7 +156,7 @@ Every pull request must be tested before review:
 > [!WARNING]
 > PRs containing any of the following will be asked to remove them before merge:
 
-- **No screenshots or screen recordings** — post demos in [Discussions](https://github.com/openmaster-ai/clawmaster/discussions) instead.
+- **No committed screenshots or screen recordings** — UI PRs should include screenshots or short recordings in the PR body under **## Screenshots**, but those assets must not be committed to the repo.
 - **No test output logs** or captured terminal output pasted inline.
 - **No debug `console.log` calls** left in production code paths.
 - **No generated files**: `dist/`, `coverage/`, `*.tsbuildinfo`, `src-tauri/target/`.

--- a/packages/backend/src/services/providerCatalogService.test.ts
+++ b/packages/backend/src/services/providerCatalogService.test.ts
@@ -101,3 +101,42 @@ test('listProviderModels uses the native Z.AI GLM catalog endpoint', async () =>
     globalThis.fetch = originalFetch
   }
 })
+
+test('listProviderModels uses the Baidu BCE Qianfan coding catalog endpoint', async () => {
+  const originalFetch = globalThis.fetch
+  let requestedUrl = ''
+  let requestedAuthorization = ''
+
+  globalThis.fetch = async (input, init) => {
+    requestedUrl = String(input)
+    requestedAuthorization = String((init?.headers as Record<string, string> | undefined)?.Authorization ?? '')
+    return new Response(JSON.stringify({
+      data: [
+        { id: 'ernie-4.5-turbo-128k', name: 'ERNIE 4.5 Turbo' },
+        { id: 'qwen3-coder-480b-a35b-instruct', name: 'Qwen3 Coder 480B' },
+        { id: 'qwen3-embedding-4b', name: 'Qwen3 Embedding' },
+      ],
+    }), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+  }
+
+  try {
+    const result = await listProviderModels({
+      providerId: 'baiduqianfancodingplan',
+      apiKey: 'bce-key',
+    })
+
+    assert.equal(requestedUrl, 'https://qianfan.baidubce.com/v2/coding/models')
+    assert.equal(requestedAuthorization, 'Bearer bce-key')
+    assert.deepEqual(result, [
+      { id: 'qianfan-code-latest', name: 'Qianfan Code Latest' },
+      { id: 'qwen3-coder-480b-a35b-instruct', name: 'Qwen3 Coder 480B' },
+    ])
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})

--- a/packages/backend/src/services/providerCatalogService.ts
+++ b/packages/backend/src/services/providerCatalogService.ts
@@ -23,6 +23,7 @@ const OPENAI_COMPATIBLE_PROVIDER_DEFAULTS: Record<string, string> = {
   'kimi-coding': 'https://api.moonshot.cn/v1',
   siliconflow: 'https://api.siliconflow.cn/v1',
   'baidu-aistudio': 'https://aistudio.baidu.com/llm/lmapi/v3',
+  baiduqianfancodingplan: 'https://qianfan.baidubce.com/v2/coding',
   zai: 'https://api.z.ai/api/paas/v4',
   openrouter: 'https://openrouter.ai/api/v1',
   cerebras: 'https://api.cerebras.ai/v1',
@@ -190,6 +191,16 @@ function filterProviderCatalogModels(providerId: string, models: ProviderCatalog
       return models.filter((model) => !/(embed|moderation)/i.test(model.id))
     case 'baidu-aistudio':
       return models.filter((model) => !/(embedding|bge|stable-diffusion|infer-|sft-)/i.test(model.id))
+    case 'baiduqianfancodingplan': {
+      const codingModels = models.filter((model) =>
+        /(?:qianfan-code|coder|codellama|sqlcoder)/i.test(model.id) &&
+        !/(embedding|bge|image|ocr|stable-diffusion|wan-|vl)/i.test(model.id),
+      )
+      if (!codingModels.some((model) => model.id === 'qianfan-code-latest')) {
+        codingModels.unshift({ id: 'qianfan-code-latest', name: 'Qianfan Code Latest' })
+      }
+      return codingModels
+    }
     case 'zai':
       return models.filter((model) => /^glm-/i.test(model.id) && !/(embedding|image|ocr)/i.test(model.id))
     default:

--- a/packages/web/src/locales/main/en.ts
+++ b/packages/web/src/locales/main/en.ts
@@ -306,6 +306,7 @@ export default {
   "providers.tierFeatured": "Featured providers",
   "providers.tierFeaturedMore": "More providers ({{count}})",
   "providers.tierCompatibleAndLocal": "Compatible & local",
+  "providers.baiduQianfanCodingPlanNote": "Uses Baidu BCE Qianfan Coding Plan's OpenAI-compatible coding endpoint.",
   "providers.ernieQuotaNote": "Get 1,000,000 free tokens after registration, then another 1,000,000 after completing your profile.",
   "providers.ernieImageNote": "Uses the same Baidu AI Studio Access Token. Verification performs a real image generation request.",
   "providers.ernieImageGuide": "Use this provider for image generation, not as the primary agent chat model.",

--- a/packages/web/src/locales/main/ja.ts
+++ b/packages/web/src/locales/main/ja.ts
@@ -306,6 +306,7 @@ export default {
   "providers.tierFeatured": "おすすめプロバイダー",
   "providers.tierFeaturedMore": "他のプロバイダー（{{count}}）",
   "providers.tierCompatibleAndLocal": "互換エンドポイント・ローカル",
+  "providers.baiduQianfanCodingPlanNote": "Baidu BCE Qianfan Coding Plan の OpenAI 互換コードモデルエンドポイントを使います。",
   "providers.ernieQuotaNote": "登録後に100万トークン、プロフィール情報の入力完了後にさらに100万トークンを受け取れます。",
   "providers.ernieImageNote": "ERNIE LLM API と同じ Baidu AI Studio アクセストークンを使います。検証では実際の画像生成リクエストを送信します。",
   "providers.ernieImageGuide": "このプロバイダーは画像生成用です。エージェントの主会話モデルには使わないでください。",

--- a/packages/web/src/locales/main/zh.ts
+++ b/packages/web/src/locales/main/zh.ts
@@ -306,6 +306,7 @@ export default {
   "providers.tierFeatured": "推荐提供商",
   "providers.tierFeaturedMore": "其他提供商（{{count}}）",
   "providers.tierCompatibleAndLocal": "兼容端点 · 本地",
+  "providers.baiduQianfanCodingPlanNote": "使用百度 BCE 千帆 Coding Plan 的 OpenAI 兼容代码模型端点。",
   "providers.ernieQuotaNote": "注册后可领取 100 万 Tokens，完善用户资料后再领取 100 万 Tokens。",
   "providers.ernieImageNote": "与文心大模型共用同一枚 Baidu AI Studio 令牌。验证时会实际发起一次图像生成请求。",
   "providers.ernieImageGuide": "这个提供商用于图像生成，不要把它当作智能体对话主模型。",

--- a/packages/web/src/modules/models/ModelsPage.tsx
+++ b/packages/web/src/modules/models/ModelsPage.tsx
@@ -259,7 +259,7 @@ export default function Models() {
   const [, setModels] = useState<ModelInfo[]>([])
   const [loading, setLoading] = useState(true)
   const [showAdd, setShowAdd] = useState(false)
-  const [preferredProvider, setPreferredProvider] = useState('baidu-aistudio')
+  const [preferredProvider, setPreferredProvider] = useState('baiduqianfancodingplan')
 
   const loadData = useCallback(async () => {
     try {
@@ -314,7 +314,7 @@ export default function Models() {
         <button
           id="models-add-provider-trigger"
           onClick={() => {
-            setPreferredProvider('baidu-aistudio')
+            setPreferredProvider('baiduqianfancodingplan')
             setShowAdd(true)
           }}
           className="button-primary"

--- a/packages/web/src/modules/models/__tests__/ModelsPage.test.tsx
+++ b/packages/web/src/modules/models/__tests__/ModelsPage.test.tsx
@@ -106,24 +106,25 @@ describe('ModelsPage', () => {
     expect(within(firstRun).getByText('Text providers')).toBeInTheDocument()
     expect(within(firstRun).getByText('Image providers')).toBeInTheDocument()
     // First-run grid surfaces the top 4 providers from PRIMARY_PROVIDERS:
-    // ERNIE LLM API plus the default featured trio (OpenAI, Anthropic, Gemini).
+    // invited sponsors first, then the default featured providers.
+    expect(within(firstRun).getByText('Baidu Qianfan Coding Plan')).toBeInTheDocument()
     expect(within(firstRun).getByText('ERNIE LLM API')).toBeInTheDocument()
     expect(within(firstRun).getByText('OpenAI')).toBeInTheDocument()
     expect(within(firstRun).getByText('Anthropic')).toBeInTheDocument()
-    expect(within(firstRun).getByText('Google Gemini')).toBeInTheDocument()
+    expect(within(firstRun).queryByText('Google Gemini')).not.toBeInTheDocument()
     expect(within(firstRun).getByText('ERNIE-Image')).toBeInTheDocument()
     expect(within(firstRun).getByText('Gemini Image')).toBeInTheDocument()
     expect(within(firstRun).getByText('GPT Image')).toBeInTheDocument()
 
-    fireEvent.click(getProviderButtonByLabel('ERNIE LLM API'))
+    fireEvent.click(getProviderButtonByLabel('Baidu Qianfan Coding Plan'))
 
     expect(await screen.findByRole('heading', { name: 'Add Provider' })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Get ERNIE LLM API Access Token →' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Get Baidu Qianfan Coding Plan BCE API Key →' })).toHaveAttribute(
       'href',
-      'https://aistudio.baidu.com/usercenter/token',
+      'https://cloud.baidu.com/doc/qianfan/s/Rmn2ms2nm',
     )
-    expect(screen.getByPlaceholderText('Enter ERNIE LLM API Access Token')).toBeInTheDocument()
-    expect(screen.getByText('Get 1,000,000 free tokens after registration, then another 1,000,000 after completing your profile.')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Enter Baidu Qianfan Coding Plan BCE API Key')).toBeInTheDocument()
+    expect(screen.getByText("Uses Baidu BCE Qianfan Coding Plan's OpenAI-compatible coding endpoint.")).toBeInTheDocument()
   })
 
   it('requires a base URL for providers that need a custom endpoint before verifying', async () => {
@@ -169,6 +170,36 @@ describe('ModelsPage', () => {
     })
     await waitFor(() => {
       expect(mockSetApiKey).toHaveBeenCalledWith('baidu-aistudio', 'bce-test-token', undefined)
+    })
+  })
+
+  it('lists Baidu Qianfan Coding Plan as an invited sponsor and can submit it', async () => {
+    renderPage()
+
+    expect(await screen.findByRole('heading', { name: 'Model Configuration' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Provider' }))
+    expect(await screen.findByRole('heading', { name: 'Add Provider' })).toBeInTheDocument()
+
+    const panel = within(getElementById('models-add-provider'))
+
+    fireEvent.click(panel.getByRole('button', { name: /Baidu Qianfan Coding Plan/ }))
+    expect(screen.getByRole('link', { name: 'Get Baidu Qianfan Coding Plan BCE API Key →' })).toHaveAttribute(
+      'href',
+      'https://cloud.baidu.com/doc/qianfan/s/Rmn2ms2nm',
+    )
+    expect(screen.getAllByText('Qianfan Code Latest / Qwen3 Coder 480B A35B Instruct / Qwen3 Coder 30B A3B Instruct').length).toBeGreaterThan(0)
+
+    fireEvent.change(screen.getByPlaceholderText('Enter Baidu Qianfan Coding Plan BCE API Key'), {
+      target: { value: 'bce-test-key' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Verify & Add' }))
+
+    await waitFor(() => {
+      expect(mockTestApiKey).toHaveBeenCalledWith('baiduqianfancodingplan', 'bce-test-key', undefined)
+    })
+    await waitFor(() => {
+      expect(mockSetApiKey).toHaveBeenCalledWith('baiduqianfancodingplan', 'bce-test-key', undefined)
     })
   })
 
@@ -246,6 +277,52 @@ describe('ModelsPage', () => {
     const picker = getElementById('models-provider-picker-zai')
     expect(within(picker!).getByText('Live catalog')).toBeInTheDocument()
     expect(within(picker!).getByRole('button', { name: /GLM-4\.6 glm-4\.6/ })).toBeInTheDocument()
+  })
+
+  it('loads the BCE coding live catalog for configured Baidu Qianfan providers', async () => {
+    mockGetConfig.mockResolvedValueOnce({
+      agents: {
+        defaults: {
+          model: { primary: 'baiduqianfancodingplan/qianfan-code-latest' },
+          imageGenerationModel: { primary: '' },
+        },
+      },
+      models: {
+        providers: {
+          baiduqianfancodingplan: {
+            apiKey: 'bce-key',
+            api: 'openai-completions',
+            baseUrl: 'https://qianfan.baidubce.com/v2/coding',
+            models: [{ id: 'qianfan-code-latest', name: 'Qianfan Code Latest' }],
+          },
+        },
+      },
+    })
+    mockGetProviderModelCatalog.mockResolvedValueOnce({
+      success: true,
+      data: [
+        { id: 'qianfan-code-latest', name: 'Qianfan Code Latest' },
+        { id: 'qwen3-coder-480b-a35b-instruct', name: 'Qwen3 Coder 480B' },
+      ],
+      error: null,
+    })
+
+    renderPage()
+
+    expect(await screen.findByRole('heading', { name: 'Model Configuration' })).toBeInTheDocument()
+    expect(screen.getByText('Baidu Qianfan Coding Plan')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(mockGetProviderModelCatalog).toHaveBeenCalledWith({
+        providerId: 'baiduqianfancodingplan',
+        apiKey: 'bce-key',
+        baseUrl: 'https://qianfan.baidubce.com/v2/coding',
+      })
+    })
+
+    fireEvent.click(within(getProviderCardByLabel('Baidu Qianfan Coding Plan')).getByRole('button', { name: 'Choose Model' }))
+    const picker = getElementById('models-provider-picker-baiduqianfancodingplan')
+    expect(within(picker!).getByText('Live catalog')).toBeInTheDocument()
+    expect(within(picker!).getByRole('button', { name: /Qwen3 Coder 480B qwen3-coder-480b-a35b-instruct/ })).toBeInTheDocument()
   })
 
   it('lists ERNIE-Image in the expanded provider catalog and surfaces text-to-image guidance', async () => {
@@ -394,8 +471,10 @@ describe('ModelsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '+ Add Provider' }))
     const addPanel = getElementById('models-add-provider')
     const providerButtons = Array.from(addPanel.querySelectorAll<HTMLButtonElement>('[data-provider-id]'))
-    expect(providerButtons[0]?.dataset.providerId).toBe('baidu-aistudio')
-    expect(providerButtons[0]?.textContent).toContain('ERNIE LLM API')
+    expect(providerButtons[0]?.dataset.providerId).toBe('baiduqianfancodingplan')
+    expect(providerButtons[0]?.textContent).toContain('Baidu Qianfan Coding Plan')
+    expect(providerButtons[1]?.dataset.providerId).toBe('baidu-aistudio')
+    expect(providerButtons[1]?.textContent).toContain('ERNIE LLM API')
   })
 
   it('shows the canonical ERNIE catalog on configured cards even when saved config still has the old model list', async () => {

--- a/packages/web/src/modules/setup/__tests__/SetupWizard.test.tsx
+++ b/packages/web/src/modules/setup/__tests__/SetupWizard.test.tsx
@@ -351,11 +351,12 @@ describe('SetupWizard', () => {
   // ──────────────────────────────────────────────────────
 
   describe('Step 2: Provider selection', () => {
-    it('shows ERNIE under the invited sponsors tier', async () => {
+    it('shows Baidu sponsor providers under the invited sponsors tier', async () => {
       render(<SetupWizard onComplete={() => {}} />)
 
       await screen.findByText('Configure LLM Provider')
       expect(screen.getByText('Invited Sponsors')).toBeInTheDocument()
+      expect(screen.getByText('Baidu Qianfan Coding Plan')).toBeInTheDocument()
       expect(screen.getByText('ERNIE LLM API')).toBeInTheDocument()
     })
 
@@ -373,6 +374,7 @@ describe('SetupWizard', () => {
 
       await screen.findByText('Configure LLM Provider')
       // Tier 1 — invited sponsors
+      expect(screen.getByText('Baidu Qianfan Coding Plan')).toBeInTheDocument()
       expect(screen.getByText('ERNIE LLM API')).toBeInTheDocument()
       // Tier 2 featured (visible by default)
       expect(screen.getByText('OpenAI')).toBeInTheDocument()
@@ -575,6 +577,45 @@ describe('SetupWizard', () => {
           providerId: 'zai',
           apiKey: 'zai-key',
           baseUrl: 'https://api.z.ai/api/paas/v4',
+        })
+      })
+    })
+
+    it('configures Baidu Qianfan Coding Plan as an invited sponsor provider', async () => {
+      render(<SetupWizard onComplete={() => {}} />)
+
+      await screen.findByText('Configure LLM Provider')
+
+      fireEvent.click(screen.getByText('Baidu Qianfan Coding Plan'))
+      expect(screen.getByRole('link', { name: 'Get Baidu Qianfan Coding Plan BCE API Key →' })).toHaveAttribute(
+        'href',
+        'https://cloud.baidu.com/doc/qianfan/s/Rmn2ms2nm',
+      )
+      expect(screen.getByText("Uses Baidu BCE Qianfan Coding Plan's OpenAI-compatible coding endpoint.")).toBeInTheDocument()
+      fireEvent.change(screen.getByPlaceholderText(/Enter Baidu Qianfan Coding Plan BCE API Key/i), {
+        target: { value: 'bce-test-key' },
+      })
+      fireEvent.click(screen.getByRole('button', { name: /Validate & Continue/i }))
+
+      await waitFor(() => {
+        expect(mockSetupAdapter.onboarding.testApiKey).toHaveBeenCalledWith(
+          'baiduqianfancodingplan',
+          'bce-test-key',
+          'https://qianfan.baidubce.com/v2/coding',
+        )
+      })
+      await waitFor(() => {
+        expect(mockSetupAdapter.onboarding.setApiKey).toHaveBeenCalledWith(
+          'baiduqianfancodingplan',
+          'bce-test-key',
+          'https://qianfan.baidubce.com/v2/coding',
+        )
+      })
+      await waitFor(() => {
+        expect(mockGetProviderModelCatalogResult).toHaveBeenCalledWith({
+          providerId: 'baiduqianfancodingplan',
+          apiKey: 'bce-test-key',
+          baseUrl: 'https://qianfan.baidubce.com/v2/coding',
         })
       })
     })

--- a/packages/web/src/modules/setup/__tests__/realAdapter.test.ts
+++ b/packages/web/src/modules/setup/__tests__/realAdapter.test.ts
@@ -312,6 +312,29 @@ describe('realSetupAdapter', () => {
     )
   })
 
+  it('writes Baidu Qianfan Coding Plan as a BCE OpenAI-compatible provider', async () => {
+    vi.mocked(setConfigResult).mockResolvedValue({
+      success: true,
+      data: undefined,
+      error: null,
+    })
+
+    await expect(
+      realSetupAdapter.onboarding.setApiKey('baiduqianfancodingplan', 'bce-test-key'),
+    ).resolves.toBeUndefined()
+
+    expect(setConfigResult).toHaveBeenCalledWith('models.providers.baiduqianfancodingplan', {
+      apiKey: 'bce-test-key',
+      api: 'openai-completions',
+      baseUrl: 'https://qianfan.baidubce.com/v2/coding',
+      models: [
+        { id: 'qianfan-code-latest', name: 'Qianfan Code Latest' },
+        { id: 'qwen3-coder-480b-a35b-instruct', name: 'Qwen3 Coder 480B A35B Instruct' },
+        { id: 'qwen3-coder-30b-a3b-instruct', name: 'Qwen3 Coder 30B A3B Instruct' },
+      ],
+    })
+  })
+
   it('throws when the ERNIE-Image runtime plugin root cannot be resolved', async () => {
     vi.mocked(setConfigResult).mockResolvedValue({
       success: true,
@@ -768,6 +791,33 @@ describe('realSetupAdapter', () => {
       },
       body: JSON.stringify({
         model: 'ernie-5.0-thinking-preview',
+        messages: [{ role: 'user', content: 'hi' }],
+        max_tokens: 1,
+      }),
+      timeoutMs: 10000,
+    })
+  })
+
+  it('probes Baidu Qianfan Coding Plan through the BCE chat completions endpoint', async () => {
+    vi.mocked(probeHttpStatusResult).mockResolvedValue({
+      success: true,
+      data: { ok: true, status: 200 },
+      error: null,
+    })
+
+    await expect(
+      realSetupAdapter.onboarding.testApiKey('baiduqianfancodingplan', 'bce-test-key'),
+    ).resolves.toBe(true)
+
+    expect(probeHttpStatusResult).toHaveBeenCalledWith({
+      url: 'https://qianfan.baidubce.com/v2/coding/chat/completions',
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer bce-test-key',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'qianfan-code-latest',
         messages: [{ role: 'user', content: 'hi' }],
         max_tokens: 1,
       }),

--- a/packages/web/src/modules/setup/types.ts
+++ b/packages/web/src/modules/setup/types.ts
@@ -95,7 +95,7 @@ export interface OnboardingState {
 }
 
 export const DEFAULT_ONBOARDING_STATE: OnboardingState = {
-  provider: 'baidu-aistudio',
+  provider: 'baiduqianfancodingplan',
   apiKey: '',
   customBaseUrl: '',
   model: '',
@@ -335,6 +335,30 @@ export const PROVIDERS: Record<string, ProviderConfig> = {
     ],
     defaultModel: 'ernie-5.0-thinking-preview',
   },
+  baiduqianfancodingplan: {
+    label: 'Baidu Qianfan Coding Plan',
+    labelByLocale: {
+      zh: '百度千帆 Coding Plan',
+      en: 'Baidu Qianfan Coding Plan',
+      ja: 'Baidu Qianfan Coding Plan',
+    },
+    api: 'openai-completions',
+    keyUrl: 'https://cloud.baidu.com/doc/qianfan/s/Rmn2ms2nm',
+    credentialLabel: 'BCE API Key',
+    credentialLabelByLocale: {
+      zh: 'BCE API Key',
+      en: 'BCE API Key',
+      ja: 'BCE APIキー',
+    },
+    noteKey: 'providers.baiduQianfanCodingPlanNote',
+    baseUrl: 'https://qianfan.baidubce.com/v2/coding',
+    models: [
+      { id: 'qianfan-code-latest', name: 'Qianfan Code Latest' },
+      { id: 'qwen3-coder-480b-a35b-instruct', name: 'Qwen3 Coder 480B A35B Instruct' },
+      { id: 'qwen3-coder-30b-a3b-instruct', name: 'Qwen3 Coder 30B A3B Instruct' },
+    ],
+    defaultModel: 'qianfan-code-latest',
+  },
   'baidu-aistudio-image': {
     label: 'ERNIE-Image',
     labelByLocale: {
@@ -521,7 +545,7 @@ export const TEXT_PROVIDER_TIERS: readonly ProviderTier[] = [
   {
     id: 'sponsors',
     labelKey: 'providers.tierInvitedSponsors',
-    members: ['baidu-aistudio'],
+    members: ['baiduqianfancodingplan', 'baidu-aistudio'],
   },
   {
     id: 'featured',
@@ -570,6 +594,7 @@ export const PRIMARY_PROVIDERS = TEXT_PROVIDER_TIERS.flatMap((tier) => [
 export const PRIMARY_IMAGE_PROVIDERS = ['baidu-aistudio-image', 'google-image', 'openai-image'] as const
 
 export const PROVIDER_BADGES: Partial<Record<keyof typeof PROVIDERS, ProviderBadgeTone>> = {
+  baiduqianfancodingplan: 'golden-sponsor',
   'baidu-aistudio': 'golden-sponsor',
   'baidu-aistudio-image': 'golden-sponsor',
 }

--- a/packages/web/src/shared/providerCatalog.test.ts
+++ b/packages/web/src/shared/providerCatalog.test.ts
@@ -193,4 +193,48 @@ describe('providerCatalog', () => {
       ])
     })
   })
+
+  describe('Baidu Qianfan Coding Plan catalog', () => {
+    it('buildProviderCatalogRequest targets the BCE coding catalog endpoint with Bearer auth', () => {
+      const request = buildProviderCatalogRequest({
+        providerId: 'baiduqianfancodingplan',
+        apiKey: 'bce-test-key',
+      })
+
+      expect(request).toEqual({
+        url: 'https://qianfan.baidubce.com/v2/coding/models',
+        headers: { Authorization: 'Bearer bce-test-key' },
+      })
+    })
+
+    it('assertSafeProviderCatalogBaseUrl accepts only the official BCE coding base path', () => {
+      expect(() =>
+        assertSafeProviderCatalogBaseUrl('baiduqianfancodingplan', 'https://qianfan.baidubce.com/v2/coding'),
+      ).not.toThrow()
+      expect(() =>
+        assertSafeProviderCatalogBaseUrl('baiduqianfancodingplan', 'https://qianfan.baidubce.com/v2'),
+      ).toThrow(/path is not allowed/)
+      expect(() =>
+        assertSafeProviderCatalogBaseUrl('baiduqianfancodingplan', 'https://example.com/v2/coding'),
+      ).toThrow(/host is not allowed/)
+    })
+
+    it('filters the BCE catalog to coding models and keeps the documented default alias', () => {
+      const result = normalizeProviderCatalogResponse('baiduqianfancodingplan', {
+        data: [
+          { id: 'ernie-4.5-turbo-128k', name: 'ERNIE 4.5 Turbo' },
+          { id: 'qwen3-coder-480b-a35b-instruct', name: 'Qwen3 Coder 480B' },
+          { id: 'codellama-7b-instruct', name: 'Code Llama 7B' },
+          { id: 'qwen3-embedding-4b', name: 'Qwen3 Embedding' },
+          { id: 'stable-diffusion-xl', name: 'Stable Diffusion XL' },
+        ],
+      })
+
+      expect(result).toEqual([
+        { id: 'qianfan-code-latest', name: 'Qianfan Code Latest' },
+        { id: 'qwen3-coder-480b-a35b-instruct', name: 'Qwen3 Coder 480B' },
+        { id: 'codellama-7b-instruct', name: 'Code Llama 7B' },
+      ])
+    })
+  })
 })

--- a/packages/web/src/shared/providerCatalog.ts
+++ b/packages/web/src/shared/providerCatalog.ts
@@ -25,6 +25,7 @@ const OPENAI_COMPATIBLE_PROVIDER_DEFAULTS: Record<string, string> = {
   'kimi-coding': 'https://api.moonshot.cn/v1',
   siliconflow: 'https://api.siliconflow.cn/v1',
   'baidu-aistudio': 'https://aistudio.baidu.com/llm/lmapi/v3',
+  baiduqianfancodingplan: 'https://qianfan.baidubce.com/v2/coding',
   zai: 'https://api.z.ai/api/paas/v4',
   openrouter: 'https://openrouter.ai/api/v1',
   cerebras: 'https://api.cerebras.ai/v1',
@@ -215,6 +216,11 @@ function isBaiduTextModel(id: string) {
   return !/(embedding|bge|stable-diffusion|infer-|sft-)/i.test(id)
 }
 
+function isBaiduQianfanCodingModel(id: string) {
+  return /(?:qianfan-code|coder|codellama|sqlcoder)/i.test(id) &&
+    !/(embedding|bge|image|ocr|stable-diffusion|wan-|vl)/i.test(id)
+}
+
 function isZaiTextModel(id: string) {
   return /^glm-/i.test(id) && !/(embedding|image|ocr)/i.test(id)
 }
@@ -227,6 +233,13 @@ function filterProviderCatalogModels(providerId: string, models: ProviderCatalog
       return models.filter((model) => isMistralTextModel(model.id))
     case 'baidu-aistudio':
       return models.filter((model) => isBaiduTextModel(model.id))
+    case 'baiduqianfancodingplan': {
+      const codingModels = models.filter((model) => isBaiduQianfanCodingModel(model.id))
+      if (!codingModels.some((model) => model.id === 'qianfan-code-latest')) {
+        codingModels.unshift({ id: 'qianfan-code-latest', name: 'Qianfan Code Latest' })
+      }
+      return codingModels
+    }
     case 'zai':
       return models.filter((model) => isZaiTextModel(model.id))
     default:

--- a/tests/desktop/harness.mjs
+++ b/tests/desktop/harness.mjs
@@ -21,6 +21,8 @@ const WEBDRIVER_SESSION_RETRY_DELAY_MS = 1_500
 const WEBDRIVER_SESSION_MAX_ATTEMPTS = 3
 const CAPABILITIES_TITLE_PATTERN = /(Capability Center|Assistant Capabilities|能力中心|助手能力|機能センター|アシスタント機能)/
 const MODELS_TITLE_PATTERN = /(Model Configuration|模型配置|モデル設定)/
+const BAIDU_QIANFAN_PROVIDER_PATTERN = /(Baidu Qianfan Coding Plan|百度千帆 Coding Plan)/
+const BAIDU_QIANFAN_NOTE_PATTERN = /(Baidu BCE Qianfan Coding Plan|百度 BCE 千帆 Coding Plan|OpenAI 互換コードモデル)/
 const ERNIE_PROVIDER_PATTERN = /(ERNIE LLM API|文心大模型|ERNIE大規模言語モデルAPI)/
 const ERNIE_QUOTA_NOTE_PATTERN = /(1,000,000 free tokens|100 万 Tokens|100万トークン)/
 const RETRYABLE_WEBDRIVER_SESSION_ERROR_PATTERNS = [
@@ -1204,22 +1206,22 @@ async function verifyDesktopModelsProviderSwitch(driver) {
   await driver.wait(until.elementLocated(By.id('models-add-provider')), NAVIGATION_TIMEOUT_MS)
   await driver.wait(async () => {
     const panel = await driver.findElement(By.id('models-add-provider'))
-    return (await panel.getAttribute('data-provider')) === 'baidu-aistudio'
+    return (await panel.getAttribute('data-provider')) === 'baiduqianfancodingplan'
   }, NAVIGATION_TIMEOUT_MS)
 
   let addProviderPanel = await driver.findElement(By.id('models-add-provider'))
   await scrollElementIntoView(driver, addProviderPanel)
 
   const panelText = await addProviderPanel.getText()
-  assert.match(panelText, ERNIE_PROVIDER_PATTERN)
-  assert.match(panelText, ERNIE_QUOTA_NOTE_PATTERN)
+  assert.match(panelText, BAIDU_QIANFAN_PROVIDER_PATTERN)
+  assert.match(panelText, BAIDU_QIANFAN_NOTE_PATTERN)
 
   const apiKeyInput = await addProviderPanel.findElement(By.id('models-provider-api-key'))
-  const erniePlaceholder = await apiKeyInput.getAttribute('placeholder')
-  assert.match(erniePlaceholder, ERNIE_PROVIDER_PATTERN)
+  const qianfanPlaceholder = await apiKeyInput.getAttribute('placeholder')
+  assert.match(qianfanPlaceholder, BAIDU_QIANFAN_PROVIDER_PATTERN)
 
   const providerNote = await addProviderPanel.findElements(By.css('#models-provider-note'))
-  assert.equal(providerNote.length, 1, 'ERNIE provider note should be visible')
+  assert.equal(providerNote.length, 1, 'Baidu Qianfan provider note should be visible')
 
   const openAiButton = await addProviderPanel.findElement(By.css('button[data-provider-id="openai"]'))
   await openAiButton.click()
@@ -1233,10 +1235,10 @@ async function verifyDesktopModelsProviderSwitch(driver) {
   const openAiInput = await addProviderPanel.findElement(By.id('models-provider-api-key'))
   const openAiPlaceholder = await openAiInput.getAttribute('placeholder')
   assert.match(openAiPlaceholder, /OpenAI/)
-  assert.notEqual(openAiPlaceholder, erniePlaceholder)
+  assert.notEqual(openAiPlaceholder, qianfanPlaceholder)
 
   const openAiNotes = await addProviderPanel.findElements(By.css('#models-provider-note'))
-  assert.equal(openAiNotes.length, 0, 'OpenAI provider should not show the ERNIE note')
+  assert.equal(openAiNotes.length, 0, 'OpenAI provider should not show the sponsor note')
 
   const ernieButton = await addProviderPanel.findElement(By.css('button[data-provider-id="baidu-aistudio"]'))
   await ernieButton.click()
@@ -1247,13 +1249,16 @@ async function verifyDesktopModelsProviderSwitch(driver) {
   }, NAVIGATION_TIMEOUT_MS)
 
   addProviderPanel = await driver.findElement(By.id('models-add-provider'))
+  const erniePanelText = await addProviderPanel.getText()
+  assert.match(erniePanelText, ERNIE_PROVIDER_PATTERN)
+  assert.match(erniePanelText, ERNIE_QUOTA_NOTE_PATTERN)
   const restoredNotes = await addProviderPanel.findElements(By.css('#models-provider-note'))
   assert.equal(restoredNotes.length, 1, 'ERNIE provider note should return after switching back')
 
   await captureDriverArtifacts(driver, 'desktop-models-provider-switch', {
     mode: 'webdriver',
     page: 'models',
-    placeholderBefore: erniePlaceholder,
+    placeholderBefore: qianfanPlaceholder,
     placeholderAfter: openAiPlaceholder,
   })
 

--- a/tests/ui/13-models-module.yaml
+++ b/tests/ui/13-models-module.yaml
@@ -2,7 +2,7 @@ suite: models-module
 name: 模型配置功能
 description: |
   验证模型配置页面的完整功能：
-  提供商列表、赞助商优先级、添加提供商、ERNIE 文案与赠送额度、测试连接、凭证入口、API Key 脱敏、默认模型指示
+  提供商列表、赞助商优先级、百度千帆与 ERNIE 赞助商文案、添加提供商、测试连接、凭证入口、API Key 脱敏、默认模型指示
 
 preconditions:
   - dev server 已启动（{BASE_URL} 可访问）
@@ -56,14 +56,14 @@ cases:
     assertions:
       - 展开"添加提供商"面板
       - 面板顶部单独显示"金牌赞助"区块
-      - '“金牌赞助”区块包含 文心大模型'
+      - '“金牌赞助”区块包含 百度千帆 Coding Plan 与 文心大模型'
       - 赞助商区块与"推荐提供商"区块分开呈现
-      - 默认选中文心大模型
+      - 默认选中百度千帆 Coding Plan
       - 显示密码类型凭证输入框
       - 显示"验证并添加"按钮
       - 显示"取消"按钮
-      - 显示"获取 文心大模型 令牌 →"链接
-      - 显示"注册后可领取 100 万 Tokens，完善用户资料后再领取 100 万 Tokens。"
+      - 显示"获取 百度千帆 Coding Plan BCE API Key →"链接
+      - 显示"使用百度 BCE 千帆 Coding Plan 的 OpenAI 兼容代码模型端点。"
 
   - id: mod-03
     name: ERNIE 令牌入口与文案
@@ -72,6 +72,10 @@ cases:
         target: text("添加提供商")
       - action: wait
         duration: 300ms
+      - action: click
+        target: text("文心大模型")
+      - action: wait
+        duration: 200ms
       - action: screenshot
         name: models-ernie-token-shortcut
     assertions:
@@ -129,7 +133,7 @@ cases:
       - action: observe
         target: 提供商选择区域
     assertions:
-      - 默认显示主要提供商（文心大模型、OpenAI、Anthropic、Google 等）
+      - 默认显示主要提供商（百度千帆 Coding Plan、文心大模型、OpenAI、Anthropic 等）
       - 显示"更多 (N 个)"链接
       - 点击后展开全部提供商列表
       - 展开后显示 Ollama、DeepSeek、智谱 等全部选项
@@ -142,6 +146,10 @@ cases:
         target: text("添加提供商")
       - action: wait
         duration: 300ms
+      - action: click
+        target: text("文心大模型")
+      - action: wait
+        duration: 200ms
       - action: fill
         target: input[placeholder*="令牌"], input[placeholder*="Access Token"]
         value: invalid-test-token
@@ -161,6 +169,10 @@ cases:
         target: text("添加提供商")
       - action: wait
         duration: 300ms
+      - action: click
+        target: text("文心大模型")
+      - action: wait
+        duration: 200ms
       - action: fill
         target: input[placeholder*="令牌"], input[placeholder*="Access Token"]
         value: temporary-token
@@ -195,5 +207,5 @@ cases:
       - action: screenshot
         name: models-reopen-panel
     assertions:
-      - 重新打开后面板默认仍指向"文心大模型"
-      - 再次显示"获取 文心大模型 令牌 →"
+      - 重新打开后面板默认仍指向"百度千帆 Coding Plan"
+      - 再次显示"获取 百度千帆 Coding Plan BCE API Key →"


### PR DESCRIPTION
## What
Adds Baidu Qianfan Coding Plan as an invited sponsor model provider in ClawMaster. The provider uses OpenClaw runtime id `baiduqianfancodingplan`, the documented BCE coding endpoint, OpenAI-compatible completions mode, and `qianfan-code-latest` as the default model.

## Why
Baidu Qianfan Coding Plan is documented as an OpenClaw-compatible coding provider and should be discoverable from Setup and Models so users can configure it without editing `openclaw.json` manually.

## How
- Added provider metadata, sponsor ordering, badge, fallback models, and zh/en/ja copy.
- Added frontend and backend live catalog allowlisting for the BCE coding endpoint and filtering for coding models.
- Updated setup, Models, adapter, catalog, desktop harness, UI plan, and contributing docs for the provider workflow.

## Screenshots
Verified in Browser Use against `http://127.0.0.1:16225/models`: Qianfan appears as the default invited sponsor, saves the test key only in masked form, loads the live catalog, `测试连接` returns `连接正常`, and the default model is `baiduqianfancodingplan/qianfan-code-latest`.

## Related Issue
Closes #105

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [x] Tests
- [ ] CI / tooling
- [ ] Chore (dependencies, config)

## Testing
- [x] `npm test` passes locally
- [x] `npm run build --workspace=@openclaw-manager/web` passes locally
- [x] `npm run build --workspace=@openclaw-manager/backend` passes locally
- [x] New or modified behavior has unit tests
- [x] No `console.log` or debug artifacts left in code
- [x] Browser Use UI walkthrough against the local web UI

## Dependency Changes
- [x] No new non-Node.js runtime dependencies introduced
- [x] No new npm packages introduced

## Checklist
- [ ] PR is a **draft** if not yet ready for review
- [x] Branch name follows convention (`feat/`, `fix/`, `chore/`, `docs/`, `test/`, `ci/`)
- [x] All new i18n strings added to `packages/web/src/locales/main/{zh,en,ja}.ts`