### PR TITLE
Fix Windows WSL workspace paths and Vitest workers

### DIFF
--- a/packages/web/src/shared/__tests__/vitestConfig.test.ts
+++ b/packages/web/src/shared/__tests__/vitestConfig.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { createWebVitestTestConfig } from '../../../vitest.testConfig'
+
+describe('createWebVitestTestConfig', () => {
+  it('uses a single thread worker on Windows to avoid fork startup timeouts', () => {
+    expect(createWebVitestTestConfig('win32')).toMatchObject({
+      pool: 'threads',
+      fileParallelism: false,
+      maxWorkers: 1,
+      minWorkers: 1,
+    })
+  })
+
+  it('does not constrain worker settings on non-Windows platforms', () => {
+    expect(createWebVitestTestConfig('linux')).not.toMatchObject({
+      pool: expect.any(String),
+      fileParallelism: expect.any(Boolean),
+      maxWorkers: expect.any(Number),
+      minWorkers: expect.any(Number),
+    })
+  })
+})

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'
+import { createWebVitestTestConfig } from './vitest.testConfig'
 
 export default defineConfig({
   plugins: [react()],
@@ -9,10 +10,5 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
-  test: {
-    environment: 'jsdom',
-    globals: true,
-    setupFiles: ['./src/test/setup.ts'],
-    include: ['src/**/*.test.{ts,tsx}'],
-  },
+  test: createWebVitestTestConfig(),
 })

--- a/packages/web/vitest.testConfig.ts
+++ b/packages/web/vitest.testConfig.ts
@@ -1,0 +1,19 @@
+export function createWebVitestTestConfig(platform: NodeJS.Platform = process.platform) {
+  const windowsWorkerConfig =
+    platform === 'win32'
+      ? {
+          pool: 'threads' as const,
+          fileParallelism: false,
+          maxWorkers: 1,
+          minWorkers: 1,
+        }
+      : {}
+
+  return {
+    environment: 'jsdom' as const,
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    include: ['src/**/*.test.{ts,tsx}'],
+    ...windowsWorkerConfig,
+  }
+}

--- a/plugins/memory-clawmaster-powermem/workspaceImport.test.ts
+++ b/plugins/memory-clawmaster-powermem/workspaceImport.test.ts
@@ -199,6 +199,26 @@ test('resolveOpenclawWorkspaceDir prefers WSL HOME when the managed data root is
   }
 })
 
+test('resolveOpenclawWorkspaceDir keeps Windows data root workspaces in Windows path style', () => {
+  const previousStateDir = process.env['OPENCLAW_STATE_DIR']
+  delete process.env['OPENCLAW_STATE_DIR']
+
+  try {
+    const workspaceDir = resolveOpenclawWorkspaceDir({
+      dataRootOverride: 'C:\\Users\\alice\\.clawmaster\\data\\named\\team-a',
+      engineOverride: 'powermem-sqlite',
+    })
+
+    assert.equal(workspaceDir, 'C:\\Users\\alice\\.openclaw-team-a\\workspace')
+  } finally {
+    if (previousStateDir === undefined) {
+      delete process.env['OPENCLAW_STATE_DIR']
+    } else {
+      process.env['OPENCLAW_STATE_DIR'] = previousStateDir
+    }
+  }
+})
+
 test('importOpenclawWorkspaceMemories reads named-profile workspace files from dataRootOverride without OPENCLAW_STATE_DIR', async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'clawmaster-plugin-workspace-import-named-'))
   const previousStateDir = process.env['OPENCLAW_STATE_DIR']

--- a/plugins/memory-clawmaster-powermem/workspaceImport.ts
+++ b/plugins/memory-clawmaster-powermem/workspaceImport.ts
@@ -92,6 +92,17 @@ function fromForwardSlashes(value: string, windowsStyle: boolean): string {
   return windowsStyle ? value.replace(/\//g, '\\') : value
 }
 
+function joinTargetRuntimePath(root: string, child: string): string {
+  const normalizedRoot = root.trim()
+  if (/^[A-Za-z]:[\\/]/.test(normalizedRoot) || normalizedRoot.startsWith('\\\\')) {
+    return path.win32.join(normalizedRoot, child)
+  }
+  if (normalizedRoot.startsWith('/')) {
+    return path.posix.join(normalizedRoot, child)
+  }
+  return path.join(normalizedRoot, child)
+}
+
 function resolvePreferredPosixHomeForMountedManagedDataRoot(normalizedDataRoot: string): string | null {
   const homeDir = process.env['HOME']?.trim()
   if (!homeDir || !homeDir.startsWith('/home/')) {
@@ -142,12 +153,12 @@ function resolveOpenclawStateDirFromManagedDataRoot(dataRoot: string): string | 
 export function resolveOpenclawWorkspaceDir(context: ManagedMemoryContext = {}): string {
   const stateDir = process.env['OPENCLAW_STATE_DIR']?.trim()
   if (stateDir) {
-    return path.join(stateDir, 'workspace')
+    return joinTargetRuntimePath(stateDir, 'workspace')
   }
   const derivedStateDir =
     context.dataRootOverride ? resolveOpenclawStateDirFromManagedDataRoot(context.dataRootOverride) : null
   if (derivedStateDir) {
-    return path.join(derivedStateDir, 'workspace')
+    return joinTargetRuntimePath(derivedStateDir, 'workspace')
   }
   return path.join(process.env['HOME'] || process.cwd(), '.openclaw', 'workspace')
 }


### PR DESCRIPTION
## What
- Preserve target runtime path style when deriving PowerMem workspace directories from managed OpenClaw data roots.
- Add regression coverage for Windows-style managed data roots and existing WSL HOME path behavior.
- Configure the web Vitest runner to use a single thread worker on Windows to avoid fork worker startup timeouts.
- Add direct coverage for the Windows-specific Vitest worker policy.

## Why
Closes #115. Windows and WSL contributor flows need reliable workspace path semantics and a test command whose exit code matches the assertion result.

## How
- Route final workspace path joins through a helper that chooses win32, posix, or host path semantics based on the target root path.
- Keep Windows data-root paths in Windows form while preserving POSIX WSL HOME paths.
- Extract the web Vitest test config into a small helper and apply Windows-only worker constraints.

## Screenshots
N/A - no user-visible UI changes.

## Verification
- npm run test:plugins
- npm run test --workspace=@openclaw-manager/web -- src/shared/__tests__/vitestConfig.test.ts
- npm run test --workspace=@openclaw-manager/web
- npm run build --workspace=@openclaw-manager/web