### PR TITLE
fix: resolve Windows ENOENT for npm-installed CLI tools (openclaw, clawprobe, npm)

### DIFF
--- a/bundled-skills/clawprobe-cost-digest/scripts/common.mjs
+++ b/bundled-skills/clawprobe-cost-digest/scripts/common.mjs
@@ -414,6 +414,7 @@ function getGlobalNpmRoot() {
       encoding: 'utf8',
       env: process.env,
       windowsHide: true,
+      shell: process.platform === 'win32',
     }).trim()
   } catch {
     return null

--- a/bundled-skills/package-download-tracker/scripts/common.mjs
+++ b/bundled-skills/package-download-tracker/scripts/common.mjs
@@ -563,6 +563,7 @@ export function defaultRunOpenclaw(args) {
   const result = spawnSync('openclaw', args, {
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
+    shell: process.platform === 'win32',
   })
   const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`.trim()
   if (result.error) throw result.error

--- a/packages/backend/src/execClawprobe.ts
+++ b/packages/backend/src/execClawprobe.ts
@@ -508,6 +508,7 @@ export async function runClawprobeJson(
     const out = await execFileAsync(cmd, cmdArgs, {
       maxBuffer: 20 * 1024 * 1024,
       env,
+      shell: process.platform === 'win32',
     })
     stdout = String(out.stdout ?? '').trim()
     stderr = String(out.stderr ?? '').trim()
@@ -596,6 +597,7 @@ export async function runClawprobeCommand(
     const out = await execFileAsync(cmd, cmdArgs, {
       maxBuffer: 20 * 1024 * 1024,
       env,
+      shell: process.platform === 'win32',
     })
     return {
       ok: true,

--- a/packages/backend/src/execOpenclaw.test.ts
+++ b/packages/backend/src/execOpenclaw.test.ts
@@ -32,15 +32,21 @@ test('resolveExecFileCommand resolves clawhub to clawhub.cmd on Windows', async 
   })
 })
 
-test('resolveExecFileCommand keeps ollama bare on Windows (native binary)', async () => {
+test('resolveExecFileCommand resolves openclaw to openclaw.cmd on Windows', async () => {
   await withPlatform('win32', () => {
-    assert.equal(resolveExecFileCommand('ollama'), 'ollama')
+    assert.equal(resolveExecFileCommand('openclaw'), 'openclaw.cmd')
   })
 })
 
-test('resolveExecFileCommand keeps openclaw bare on Windows', async () => {
+test('resolveExecFileCommand resolves clawprobe to clawprobe.cmd on Windows', async () => {
   await withPlatform('win32', () => {
-    assert.equal(resolveExecFileCommand('openclaw'), 'openclaw')
+    assert.equal(resolveExecFileCommand('clawprobe'), 'clawprobe.cmd')
+  })
+})
+
+test('resolveExecFileCommand keeps ollama bare on Windows (native binary)', async () => {
+  await withPlatform('win32', () => {
+    assert.equal(resolveExecFileCommand('ollama'), 'ollama')
   })
 })
 
@@ -50,6 +56,7 @@ test('resolveExecFileCommand returns bare command on non-Windows for all command
     assert.equal(resolveExecFileCommand('clawhub'), 'clawhub')
     assert.equal(resolveExecFileCommand('ollama'), 'ollama')
     assert.equal(resolveExecFileCommand('openclaw'), 'openclaw')
+    assert.equal(resolveExecFileCommand('clawprobe'), 'clawprobe')
   })
 })
 
@@ -59,13 +66,14 @@ test('needsShellOnWindows returns true for npm-installed commands on Windows', a
   await withPlatform('win32', () => {
     assert.equal(needsShellOnWindows('npm'), true)
     assert.equal(needsShellOnWindows('clawhub'), true)
+    assert.equal(needsShellOnWindows('openclaw'), true)
+    assert.equal(needsShellOnWindows('clawprobe'), true)
   })
 })
 
 test('needsShellOnWindows returns false for native binaries on Windows', async () => {
   await withPlatform('win32', () => {
     assert.equal(needsShellOnWindows('ollama'), false)
-    assert.equal(needsShellOnWindows('openclaw'), false)
   })
 })
 
@@ -74,6 +82,8 @@ test('needsShellOnWindows returns false for everything on non-Windows', async ()
     assert.equal(needsShellOnWindows('npm'), false)
     assert.equal(needsShellOnWindows('clawhub'), false)
     assert.equal(needsShellOnWindows('ollama'), false)
+    assert.equal(needsShellOnWindows('openclaw'), false)
+    assert.equal(needsShellOnWindows('clawprobe'), false)
   })
 })
 

--- a/packages/backend/src/execOpenclaw.ts
+++ b/packages/backend/src/execOpenclaw.ts
@@ -297,53 +297,50 @@ function execOpenclawSpawnStdin(
 ): Promise<{ code: number; stdout: string; stderr: string }> {
   const maxBuffer = 20 * 1024 * 1024
   return new Promise((resolve, reject) => {
+    const isWin32 = process.platform === 'win32'
     const child = spawn(bin, args, {
       env: process.env,
       stdio: ['pipe', 'pipe', 'pipe'],
-      shell: process.platform === 'win32',
+      shell: isWin32,
+      windowsHide: true,
     })
     let killedByTimeout = false
     let timer: ReturnType<typeof setTimeout> | undefined
+
+    /** On Windows, `shell: true` spawns cmd.exe as the direct child; killing the
+     *  child only kills cmd.exe, leaving the real process orphaned. Use
+     *  `taskkill /T /F /PID` to kill the entire process tree instead. */
+    const killChild = () => {
+      if (isWin32 && child.pid) {
+        try {
+          execFileSync('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore' })
+        } catch {
+          try { child.kill('SIGKILL') } catch { /* ignore */ }
+        }
+      } else {
+        try { child.kill('SIGKILL') } catch { /* ignore */ }
+      }
+    }
 
     const accOut = { s: '' }
     const accErr = { s: '' }
     child.stdout?.on('data', (b) => {
       accOut.s += b.toString('utf8')
       if (accOut.s.length > maxBuffer) {
-        try {
-          child.kill('SIGKILL')
-        } catch {
-          /* ignore */
-        }
+        killChild()
       }
     })
     child.stderr?.on('data', (b) => {
       accErr.s += b.toString('utf8')
       if (accErr.s.length > maxBuffer) {
-        try {
-          child.kill('SIGKILL')
-        } catch {
-          /* ignore */
-        }
+        killChild()
       }
     })
 
     if (opts.timeoutMs != null && opts.timeoutMs > 0) {
       timer = setTimeout(() => {
         killedByTimeout = true
-        try {
-          child.kill('SIGTERM')
-        } catch {
-          /* ignore */
-        }
-        const killHard = setTimeout(() => {
-          try {
-            child.kill('SIGKILL')
-          } catch {
-            /* ignore */
-          }
-        }, 5000)
-        killHard.unref()
+        killChild()
       }, opts.timeoutMs)
     }
 
@@ -417,6 +414,7 @@ export function execOpenclaw(
       maxBuffer: 20 * 1024 * 1024,
       env: command.env,
       shell: process.platform === 'win32',
+      windowsHide: true,
     }
     if (opts?.timeoutMs != null && opts.timeoutMs > 0) {
       execOpts.timeout = opts.timeoutMs
@@ -727,11 +725,26 @@ export function spawnOpenclawGatewayStart(): Promise<void> {
     repairDarwinGatewayLaunchAgentIfNeeded()
       .then(() => {
         const command = resolveOpenclawCommand()
+        const isWin32 = process.platform === 'win32'
         const child = spawn(command.bin, [...command.argsPrefix, 'gateway', 'start'], {
           stdio: ['ignore', 'pipe', 'pipe'],
           env: command.env,
-          shell: process.platform === 'win32',
+          shell: isWin32,
+          windowsHide: true,
         })
+        /** On Windows, kill the entire process tree (cmd.exe + child) so
+         *  orphaned openclaw processes don't survive a gateway start failure. */
+        const killTree = () => {
+          if (isWin32 && child.pid) {
+            try {
+              execFileSync('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore' })
+            } catch {
+              try { child.kill() } catch { /* ignore */ }
+            }
+          } else {
+            try { child.kill() } catch { /* ignore */ }
+          }
+        }
         let out = ''
         let err = ''
         child.stdout?.on('data', (c) => {
@@ -740,7 +753,10 @@ export function spawnOpenclawGatewayStart(): Promise<void> {
         child.stderr?.on('data', (c) => {
           err += String(c)
         })
-        child.once('error', reject)
+        child.once('error', (e) => {
+          killTree()
+          reject(e)
+        })
         child.once('close', (code) => {
           if (code === 0) resolve()
           else {

--- a/packages/backend/src/execOpenclaw.ts
+++ b/packages/backend/src/execOpenclaw.ts
@@ -300,6 +300,7 @@ function execOpenclawSpawnStdin(
     const child = spawn(bin, args, {
       env: process.env,
       stdio: ['pipe', 'pipe', 'pipe'],
+      shell: process.platform === 'win32',
     })
     let killedByTimeout = false
     let timer: ReturnType<typeof setTimeout> | undefined
@@ -415,6 +416,7 @@ export function execOpenclaw(
     const execOpts: ExecOpenclawFileOpts = {
       maxBuffer: 20 * 1024 * 1024,
       env: command.env,
+      shell: process.platform === 'win32',
     }
     if (opts?.timeoutMs != null && opts.timeoutMs > 0) {
       execOpts.timeout = opts.timeoutMs
@@ -515,7 +517,7 @@ export function execShellCommand(command: string): Promise<{
   })
 }
 
-const NPM_INSTALLED_COMMANDS = new Set(['npm', 'clawhub'])
+const NPM_INSTALLED_COMMANDS = new Set(['npm', 'clawhub', 'openclaw', 'clawprobe'])
 
 export function resolveExecFileCommand(cmd: string): string {
   if (process.platform === 'win32' && NPM_INSTALLED_COMMANDS.has(cmd)) {
@@ -728,6 +730,7 @@ export function spawnOpenclawGatewayStart(): Promise<void> {
         const child = spawn(command.bin, [...command.argsPrefix, 'gateway', 'start'], {
           stdio: ['ignore', 'pipe', 'pipe'],
           env: command.env,
+          shell: process.platform === 'win32',
         })
         let out = ''
         let err = ''

--- a/packages/backend/src/execOpenclaw.ts
+++ b/packages/backend/src/execOpenclaw.ts
@@ -309,8 +309,10 @@ function execOpenclawSpawnStdin(
 
     /** On Windows, `shell: true` spawns cmd.exe as the direct child; killing the
      *  child only kills cmd.exe, leaving the real process orphaned. Use
-     *  `taskkill /T /F /PID` to kill the entire process tree instead. */
-    const killChild = () => {
+     *  `taskkill /T /F /PID` to kill the entire process tree instead.
+     *  On non-Windows, send SIGKILL directly (immediate force-kill for
+     *  buffer overflow; graceful SIGTERM is handled in the timeout path). */
+    const forceKill = () => {
       if (isWin32 && child.pid) {
         try {
           execFileSync('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore' })
@@ -327,20 +329,36 @@ function execOpenclawSpawnStdin(
     child.stdout?.on('data', (b) => {
       accOut.s += b.toString('utf8')
       if (accOut.s.length > maxBuffer) {
-        killChild()
+        forceKill()
       }
     })
     child.stderr?.on('data', (b) => {
       accErr.s += b.toString('utf8')
       if (accErr.s.length > maxBuffer) {
-        killChild()
+        forceKill()
       }
     })
 
     if (opts.timeoutMs != null && opts.timeoutMs > 0) {
       timer = setTimeout(() => {
         killedByTimeout = true
-        killChild()
+        if (isWin32) {
+          forceKill()
+        } else {
+          try {
+            child.kill('SIGTERM')
+          } catch {
+            /* ignore */
+          }
+          const killHard = setTimeout(() => {
+            try {
+              child.kill('SIGKILL')
+            } catch {
+              /* ignore */
+            }
+          }, 5000)
+          killHard.unref()
+        }
       }, opts.timeoutMs)
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -666,7 +666,24 @@ fn openclaw_cmd() -> Command {
         return c;
     }
 
-    let mut c = Command::new(openclaw_executable_path());
+    let exe_path = openclaw_executable_path();
+    #[cfg(target_os = "windows")]
+    {
+        // On Windows, npm-installed CLIs are .cmd scripts that cmd.exe must interpret.
+        // Command::new cannot execute .cmd files directly.
+        let needs_cmd = exe_path.extension().map_or(true, |ext| ext == "cmd" || ext == "CMD");
+        if needs_cmd {
+            let mut c = Command::new("cmd");
+            c.stdin(Stdio::null())
+                .arg("/C")
+                .arg(&exe_path);
+            for arg in get_openclaw_profile_args(&get_openclaw_profile_selection()) {
+                c.arg(arg);
+            }
+            return c;
+        }
+    }
+    let mut c = Command::new(exe_path);
     c.stdin(Stdio::null());
     for arg in get_openclaw_profile_args(&get_openclaw_profile_selection()) {
         c.arg(arg);
@@ -690,7 +707,19 @@ fn clawprobe_cmd() -> Command {
         return c;
     }
 
-    Command::new(clawprobe_executable_path())
+    let exe_path = clawprobe_executable_path();
+    #[cfg(target_os = "windows")]
+    {
+        let needs_cmd = exe_path.extension().map_or(true, |ext| ext == "cmd" || ext == "CMD");
+        if needs_cmd {
+            let mut c = Command::new("cmd");
+            c.stdin(Stdio::null())
+                .arg("/C")
+                .arg(&exe_path);
+            return c;
+        }
+    }
+    Command::new(exe_path)
 }
 
 fn try_resolve_clawprobe_via_login_shell() -> Option<PathBuf> {
@@ -3153,6 +3182,20 @@ fn normalize_skillguard_scan_output(
 
 fn run_skillguard_scan_host(skill_dir: &Path) -> Result<serde_json::Value, String> {
     let skill_dir_string = skill_dir.to_string_lossy().to_string();
+    #[cfg(target_os = "windows")]
+    let output = {
+        let npm_path = resolve_system_command_path("npm");
+        let mut all_args = vec!["/C".to_string(), npm_path.to_string_lossy().to_string()];
+        all_args.extend(["exec", "--yes", "@clawmaster/skillguard-cli", "--", &skill_dir_string, "--json"].iter().map(|s| s.to_string()));
+        Command::new("cmd")
+            .args(&all_args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .map_err(|e| cmd_err_d("SKILLGUARD_SCAN_FAILED", e))?
+    };
+    #[cfg(not(target_os = "windows"))]
     let output = Command::new(resolve_system_command_path("npm"))
         .args([
             "exec",
@@ -6352,6 +6395,12 @@ fn save_clawmaster_npm_proxy(enabled: Option<bool>) -> Result<ClawmasterNpmProxy
 }
 
 fn npm_root_g() -> Result<String, String> {
+    #[cfg(target_os = "windows")]
+    let output = Command::new("cmd")
+        .args(["/C", "npm", "root", "-g"])
+        .output()
+        .map_err(|e| cmd_err_d("NPM_ROOT_SPAWN_FAILED", e))?;
+    #[cfg(not(target_os = "windows"))]
     let output = Command::new("npm")
         .args(["root", "-g"])
         .output()
@@ -6381,7 +6430,15 @@ fn npm_uninstall_global_robust(pkg: &str) -> (bool, i32, String, String) {
     }
 
     fn run_npm(args: &[&str]) -> (bool, i32, String, String) {
-        match Command::new("npm").args(args).output() {
+        #[cfg(target_os = "windows")]
+        let result = {
+            let mut all_args = vec!["/C".to_string(), "npm".to_string()];
+            all_args.extend(args.iter().map(|s| s.to_string()));
+            Command::new("cmd").args(&all_args).output()
+        };
+        #[cfg(not(target_os = "windows"))]
+        let result = Command::new("npm").args(args).output();
+        match result {
             Ok(output) => {
                 let stdout = String::from_utf8_lossy(&output.stdout).to_string();
                 let stderr = String::from_utf8_lossy(&output.stderr).to_string();
@@ -6522,6 +6579,14 @@ fn cmp_openclaw_version_desc(a: &str, b: &str) -> std::cmp::Ordering {
 fn list_npm_package_versions(package_name: &str) -> Result<OpenclawNpmVersionsDto, String> {
     fn npm_stdout(args: &[String]) -> Result<String, String> {
         let args = with_configured_npm_registry_args(args);
+        #[cfg(target_os = "windows")]
+        let output = {
+            let mut all_args = vec!["/C".to_string(), "npm".to_string()];
+            all_args.extend(args.iter().cloned());
+            Command::new("cmd").args(&all_args).output()
+                .map_err(|e| cmd_err_d("NPM_SPAWN_FAILED", e))?
+        };
+        #[cfg(not(target_os = "windows"))]
         let output = Command::new("npm")
             .args(args)
             .output()
@@ -6605,6 +6670,14 @@ fn run_npm_install_openclaw_global(spec: &str) -> Result<NpmUninstallOutput, Str
     };
     let args =
         with_configured_npm_registry_args(&["install".to_string(), "-g".to_string(), pkg.clone()]);
+    #[cfg(target_os = "windows")]
+    let output = {
+        let mut all_args = vec!["/C".to_string(), "npm".to_string()];
+        all_args.extend(args.iter().cloned());
+        Command::new("cmd").args(&all_args).output()
+            .map_err(|e| cmd_err_d("NPM_SPAWN_FAILED", e))?
+    };
+    #[cfg(not(target_os = "windows"))]
     let output = Command::new("npm")
         .args(&args)
         .output()
@@ -6650,6 +6723,14 @@ fn npm_install_openclaw_from_file(file_path: String) -> Result<NpmUninstallOutpu
     let s = canon.to_string_lossy().to_string();
     let args =
         with_configured_npm_registry_args(&["install".to_string(), "-g".to_string(), s.clone()]);
+    #[cfg(target_os = "windows")]
+    let output = {
+        let mut all_args = vec!["/C".to_string(), "npm".to_string()];
+        all_args.extend(args.iter().cloned());
+        Command::new("cmd").args(&all_args).output()
+            .map_err(|e| cmd_err_d("NPM_SPAWN_FAILED", e))?
+    };
+    #[cfg(not(target_os = "windows"))]
     let output = Command::new("npm")
         .args(&args)
         .output()
@@ -8369,6 +8450,28 @@ fn run_system_command(cmd: String, args: Vec<String>) -> Result<String, String> 
         return Err(cmd_err_d("SYSTEM_CMD_FAILED", msg.trim()));
     }
 
+    // On Windows, npm-installed CLIs (npm, clawhub) are .cmd scripts that cmd.exe must interpret.
+    #[cfg(target_os = "windows")]
+    {
+        let needs_cmd = program.extension().map_or(trimmed == "npm" || trimmed == "clawhub", |ext| ext == "cmd" || ext == "CMD");
+        if needs_cmd {
+            let mut all_args = vec![program.to_string_lossy().to_string()];
+            all_args.extend(normalized_args.iter().cloned());
+            let output = Command::new("cmd")
+                .arg("/C")
+                .args(&all_args)
+                .stdin(Stdio::null())
+                .output()
+                .map_err(|e| cmd_err_d("SYSTEM_CMD_SPAWN_FAILED", e))?;
+            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            if output.status.success() {
+                return Ok(stdout);
+            }
+            let msg = if !stderr.trim().is_empty() { stderr } else if !stdout.trim().is_empty() { stdout } else { format!("exit {:?}", output.status.code()) };
+            return Err(cmd_err_d("SYSTEM_CMD_FAILED", msg.trim()));
+        }
+    }
     let output = Command::new(program)
         .args(&normalized_args)
         .stdin(Stdio::null())


### PR DESCRIPTION
## What

Fixes `spawn ... ENOENT` errors on Windows when ClawMaster tries to launch npm-installed CLI tools like `openclaw`, `clawprobe`, and `npm`.

Closes #140

## Why

On Windows, npm global installs create `.cmd` wrapper scripts (e.g., `openclaw.cmd`) instead of bare executables. Node.js `child_process.spawn()`/`execFile()` and Rust `std::process::Command::new()` cannot execute `.cmd` files directly — they require either `shell: true` or explicit `cmd /C` invocation.

When the app calls `spawn("openclaw", ...)` on Windows, it fails with ENOENT because there is no file literally named `openclaw` (only `openclaw.cmd`).

## How

### Backend (Node.js) — `packages/backend/src/execOpenclaw.ts`
- Added `openclaw` and `clawprobe` to `NPM_INSTALLED_COMMANDS` so `resolveExecFileCommand()` appends `.cmd` on Windows
- Added `shell: process.platform === "win32"` to `execOpenclawSpawnStdin()`, `execOpenclaw()`, and `spawnOpenclawGatewayStart()`

### Backend (Node.js) — `packages/backend/src/execClawprobe.ts`
- Added `shell: process.platform === "win32"` to `runClawprobeJson()` and `runClawprobeCommand()`

### Tests — `packages/backend/src/execOpenclaw.test.ts`
- Updated assertions: `openclaw` → `openclaw.cmd`, `clawprobe` → `clawprobe.cmd` on Windows
- Added `needsShellOnWindows` coverage for `openclaw` and `clawprobe`

### Bundled Skills
- `clawprobe-cost-digest/scripts/common.mjs`: Added `shell: process.platform === "win32"` to `getGlobalNpmRoot()`
- `package-download-tracker/scripts/common.mjs`: Added `shell: process.platform === "win32"` to `defaultRunOpenclaw()`

### Rust/Tauri — `src-tauri/src/lib.rs`
- `openclaw_cmd()` / `clawprobe_cmd()`: Wrap with `cmd /C` when resolved path is a `.cmd` file or bare name
- All `Command::new("npm")` calls: Use `cmd /C npm` on Windows
- `run_system_command()`: Wrap with `cmd /C` on Windows for `.cmd` files and known npm tools

## Screenshots

N/A — backend/CLI fix with no UI changes.