### PR TITLE
Fix WeChat QR login cancellation and recovery

### DIFF
--- a/packages/web/src/locales/main/en.ts
+++ b/packages/web/src/locales/main/en.ts
@@ -1020,6 +1020,8 @@ export default {
   "channel.qr.scanHint": "Scan the QR code with your phone app to log in",
   "channel.qr.connected": "Connected!",
   "channel.qr.timeout": "Login timed out. Please retry.",
+  "channel.qr.timeoutHint": "The QR code may have expired. Refresh it to request a new one.",
+  "channel.qr.refresh": "Refresh QR code",
   "channel.feishu.permissionsTitle": "Permissions template (copy to Feishu permission config)",
   "common.copyToClipboard": "Copy",
   "channel.wechat.step1.highlight": "Automatically installed when you click Start",

--- a/packages/web/src/locales/main/ja.ts
+++ b/packages/web/src/locales/main/ja.ts
@@ -1020,6 +1020,8 @@ export default {
   "channel.qr.scanHint": "スマホアプリでQRコードをスキャンしてログイン",
   "channel.qr.connected": "接続成功！",
   "channel.qr.timeout": "ログインがタイムアウトしました。再試行してください。",
+  "channel.qr.timeoutHint": "QRコードの有効期限が切れた可能性があります。更新して新しいコードを取得してください。",
+  "channel.qr.refresh": "QRコードを更新",
   "channel.feishu.permissionsTitle": "権限テンプレート（飛書の権限設定にコピー）",
   "common.copyToClipboard": "コピー",
   "channel.wechat.step1.highlight": "開始をクリックすると自動インストールされます",

--- a/packages/web/src/locales/main/zh.ts
+++ b/packages/web/src/locales/main/zh.ts
@@ -1020,6 +1020,8 @@ export default {
   "channel.qr.scanHint": "请用手机 App 扫描二维码完成登录",
   "channel.qr.connected": "连接成功！",
   "channel.qr.timeout": "登录超时，请重试",
+  "channel.qr.timeoutHint": "二维码可能已过期，请刷新后重新扫码。",
+  "channel.qr.refresh": "刷新二维码",
   "channel.feishu.permissionsTitle": "权限模板（一键复制到飞书权限配置）",
   "common.copyToClipboard": "复制",
   "channel.wechat.step1.highlight": "点击开始后自动安装，无需手动操作",

--- a/packages/web/src/modules/channels/ChannelsPage.tsx
+++ b/packages/web/src/modules/channels/ChannelsPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import type { LucideIcon } from 'lucide-react'
@@ -136,10 +136,13 @@ type WechatSetupStage =
   | 'installing'
   | 'ready'
   | 'scanning'
+  | 'timedOut'
   | 'connected'
   | 'error'
 
 const WECHAT_PLUGIN_PACKAGE = '@tencent-weixin/openclaw-weixin'
+const WECHAT_QR_POLL_INTERVAL_MS = 3000
+const WECHAT_QR_MAX_POLLS = 20
 
 export default function Channels() {
   const { t, i18n } = useTranslation()
@@ -174,10 +177,17 @@ export default function Channels() {
   const [wechatSetupStage, setWechatSetupStage] = useState<WechatSetupStage>('idle')
   const [wechatSetupError, setWechatSetupError] = useState<string | null>(null)
   const [wechatPluginInstalled, setWechatPluginInstalled] = useState(false)
+  const wechatScanAttemptRef = useRef(0)
   const [logsOpen, setLogsOpen] = useState(false)
   const [feedback, setFeedback] = useState<{ tone: 'info' | 'success' | 'error'; message: string } | null>(null)
   const [pendingRemoval, setPendingRemoval] = useState<{ typeId: string; label: string } | null>(null)
   const [pendingAccountRemoval, setPendingAccountRemoval] = useState<{ typeId: string; accountId: string } | null>(null)
+
+  useEffect(() => {
+    return () => {
+      wechatScanAttemptRef.current += 1
+    }
+  }, [])
 
   const channels: Record<string, OpenClawChannelEntry> = config?.channels || {}
   const allAgents = config?.agents?.list ?? []
@@ -240,6 +250,7 @@ export default function Channels() {
   }
 
   async function openWechatSetup() {
+    wechatScanAttemptRef.current += 1
     setWechatSetupOpen(true)
     setWechatSetupError(null)
     setWechatSetupStage('checking')
@@ -270,24 +281,43 @@ export default function Channels() {
   }
 
   async function startWechatQrLogin() {
+    const attemptId = wechatScanAttemptRef.current + 1
+    wechatScanAttemptRef.current = attemptId
     setWechatSetupError(null)
     setWechatSetupStage('scanning')
-    execCommand('openclaw', ['channels', 'login', '--channel', 'wechat']).catch(() => {})
-    for (let i = 0; i < 60; i++) {
-      await new Promise((resolve) => setTimeout(resolve, 3000))
+    try {
+      await execCommand('openclaw', ['channels', 'login', '--channel', 'wechat'])
+    } catch (err) {
+      if (wechatScanAttemptRef.current !== attemptId) return
+      setWechatSetupError(err instanceof Error ? err.message : String(err))
+      setWechatSetupStage('error')
+      return
+    }
+    for (let i = 0; i < WECHAT_QR_MAX_POLLS; i++) {
+      await new Promise((resolve) => setTimeout(resolve, WECHAT_QR_POLL_INTERVAL_MS))
+      if (wechatScanAttemptRef.current !== attemptId) return
       try {
         const out = await execCommand('openclaw', ['channels', 'status', '--channel', 'wechat'])
+        if (wechatScanAttemptRef.current !== attemptId) return
         if (out.includes('connected') || out.includes('ready') || out.includes('online')) {
           setWechatSetupStage('connected')
           await refetch()
           return
         }
       } catch {
+        if (wechatScanAttemptRef.current !== attemptId) return
         // Keep polling while the login session is initializing.
       }
     }
-    setWechatSetupError(t('channel.qr.timeout'))
-    setWechatSetupStage('error')
+    if (wechatScanAttemptRef.current !== attemptId) return
+    setWechatSetupStage('timedOut')
+  }
+
+  function closeWechatSetup() {
+    wechatScanAttemptRef.current += 1
+    setWechatSetupOpen(false)
+    setWechatSetupError(null)
+    setWechatSetupStage('idle')
   }
 
   function openChannelEditor(typeId: string, accountId?: string) {
@@ -848,7 +878,7 @@ export default function Channels() {
           role="dialog"
           aria-modal="true"
           aria-labelledby="wechat-setup-title"
-          onClick={() => wechatSetupStage !== 'installing' && wechatSetupStage !== 'scanning' && setWechatSetupOpen(false)}
+          onClick={() => wechatSetupStage !== 'installing' && closeWechatSetup()}
         >
           <div
             className="w-[min(100%,36rem)] rounded-[1.5rem] border border-border bg-card p-6 shadow-lg space-y-4"
@@ -921,6 +951,16 @@ export default function Channels() {
                 </div>
               ) : null}
 
+              {wechatSetupStage === 'timedOut' ? (
+                <div className="space-y-3">
+                  <div className="inline-flex items-center gap-2 text-sm text-amber-700 dark:text-amber-300">
+                    <CircleDashed className="h-4 w-4" />
+                    {t('channel.qr.timeout')}
+                  </div>
+                  <div className="inline-note text-sm">{t('channel.qr.timeoutHint')}</div>
+                </div>
+              ) : null}
+
               {wechatSetupStage === 'connected' ? (
                 <div className="inline-flex items-center gap-2 text-sm text-emerald-700 dark:text-emerald-300">
                   <CheckCircle2 className="h-4 w-4" />
@@ -937,8 +977,8 @@ export default function Channels() {
               <button
                 type="button"
                 className="button-secondary px-3 py-1.5 text-sm"
-                onClick={() => setWechatSetupOpen(false)}
-                disabled={wechatSetupStage === 'installing' || wechatSetupStage === 'scanning'}
+                onClick={closeWechatSetup}
+                disabled={wechatSetupStage === 'installing'}
               >
                 {t('common.cancel')}
               </button>
@@ -959,6 +999,15 @@ export default function Channels() {
                   onClick={() => void startWechatQrLogin()}
                 >
                   {t('channel.qr.start')}
+                </button>
+              )}
+              {wechatSetupStage === 'timedOut' && (
+                <button
+                  type="button"
+                  className="button-primary px-3 py-1.5 text-sm"
+                  onClick={() => void startWechatQrLogin()}
+                >
+                  {t('channel.qr.refresh')}
                 </button>
               )}
               {wechatSetupStage === 'error' && wechatPluginInstalled && (

--- a/packages/web/src/modules/channels/ChannelsPage.tsx
+++ b/packages/web/src/modules/channels/ChannelsPage.tsx
@@ -280,19 +280,28 @@ export default function Channels() {
     }
   }
 
+  async function stopWechatQrLoginSession() {
+    try {
+      await execCommand('openclaw', ['channels', 'logout', '--channel', 'wechat'])
+    } catch {
+      // Ignore cleanup failures so the modal can still close or retry locally.
+    }
+  }
+
   async function startWechatQrLogin() {
+    if (wechatSetupStage === 'timedOut') {
+      await stopWechatQrLoginSession()
+    }
     const attemptId = wechatScanAttemptRef.current + 1
     wechatScanAttemptRef.current = attemptId
     setWechatSetupError(null)
     setWechatSetupStage('scanning')
-    try {
-      await execCommand('openclaw', ['channels', 'login', '--channel', 'wechat'])
-    } catch (err) {
+    void execCommand('openclaw', ['channels', 'login', '--channel', 'wechat']).catch((err) => {
       if (wechatScanAttemptRef.current !== attemptId) return
+      wechatScanAttemptRef.current += 1
       setWechatSetupError(err instanceof Error ? err.message : String(err))
       setWechatSetupStage('error')
-      return
-    }
+    })
     for (let i = 0; i < WECHAT_QR_MAX_POLLS; i++) {
       await new Promise((resolve) => setTimeout(resolve, WECHAT_QR_POLL_INTERVAL_MS))
       if (wechatScanAttemptRef.current !== attemptId) return
@@ -300,6 +309,7 @@ export default function Channels() {
         const out = await execCommand('openclaw', ['channels', 'status', '--channel', 'wechat'])
         if (wechatScanAttemptRef.current !== attemptId) return
         if (out.includes('connected') || out.includes('ready') || out.includes('online')) {
+          wechatScanAttemptRef.current += 1
           setWechatSetupStage('connected')
           await refetch()
           return
@@ -310,14 +320,20 @@ export default function Channels() {
       }
     }
     if (wechatScanAttemptRef.current !== attemptId) return
+    wechatScanAttemptRef.current += 1
     setWechatSetupStage('timedOut')
   }
 
   function closeWechatSetup() {
+    const shouldStopActiveSession =
+      wechatSetupStage === 'scanning' || wechatSetupStage === 'timedOut'
     wechatScanAttemptRef.current += 1
     setWechatSetupOpen(false)
     setWechatSetupError(null)
     setWechatSetupStage('idle')
+    if (shouldStopActiveSession) {
+      void stopWechatQrLoginSession()
+    }
   }
 
   function openChannelEditor(typeId: string, accountId?: string) {

--- a/packages/web/src/modules/channels/__tests__/ChannelsPage.test.tsx
+++ b/packages/web/src/modules/channels/__tests__/ChannelsPage.test.tsx
@@ -120,6 +120,9 @@ describe('ChannelsPage', () => {
       if (cmd === 'openclaw' && args[0] === 'channels' && args[1] === 'login') {
         return 'login started'
       }
+      if (cmd === 'openclaw' && args[0] === 'channels' && args[1] === 'logout') {
+        return 'logout started'
+      }
       if (cmd === 'openclaw' && args[0] === 'channels' && args[1] === 'status') {
         return 'waiting'
       }
@@ -143,6 +146,8 @@ describe('ChannelsPage', () => {
     fireEvent.click(cancelButton)
     expect(screen.queryByRole('dialog', { name: '微信' })).not.toBeInTheDocument()
 
+    await act(async () => {})
+
     await act(async () => {
       await vi.advanceTimersByTimeAsync(3000)
     })
@@ -156,6 +161,53 @@ describe('ChannelsPage', () => {
         args[3] === 'wechat',
     )
     expect(statusCalls).toHaveLength(0)
+    expect(mockExecCommand).toHaveBeenCalledWith('openclaw', [
+      'channels',
+      'logout',
+      '--channel',
+      'wechat',
+    ])
+  })
+
+  it('polls WeChat status while the QR login command is still pending', async () => {
+    let resolveLogin: (() => void) | null = null
+    mockExecCommand.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'npm' && args[0] === 'list') {
+        return Promise.resolve('installed')
+      }
+      if (cmd === 'openclaw' && args[0] === 'channels' && args[1] === 'login') {
+        return new Promise<string>((resolve) => {
+          resolveLogin = () => resolve('login finished')
+        })
+      }
+      if (cmd === 'openclaw' && args[0] === 'channels' && args[1] === 'status') {
+        return Promise.resolve('waiting')
+      }
+      return Promise.resolve('')
+    })
+
+    renderChannels()
+
+    expect(await screen.findByText('推荐入口')).toBeInTheDocument()
+    fireEvent.click(screen.getAllByRole('button', { name: '开始配置' })[1])
+
+    await screen.findByText('已安装')
+    vi.useFakeTimers()
+    fireEvent.click(screen.getByRole('button', { name: '开始扫码登录' }))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+
+    expect(mockExecCommand).toHaveBeenCalledWith('openclaw', [
+      'channels',
+      'status',
+      '--channel',
+      'wechat',
+    ])
+
+    resolveLogin?.()
+    await act(async () => {})
   })
 
   it('shows timeout recovery and refreshes the WeChat QR login after expiry', async () => {
@@ -165,6 +217,9 @@ describe('ChannelsPage', () => {
       }
       if (cmd === 'openclaw' && args[0] === 'channels' && args[1] === 'login') {
         return 'login started'
+      }
+      if (cmd === 'openclaw' && args[0] === 'channels' && args[1] === 'logout') {
+        return 'logout started'
       }
       if (cmd === 'openclaw' && args[0] === 'channels' && args[1] === 'status') {
         return 'waiting'
@@ -191,6 +246,7 @@ describe('ChannelsPage', () => {
     expect(screen.getByText('二维码可能已过期，请刷新后重新扫码。')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: '刷新二维码' }))
+    await act(async () => {})
 
     const loginCalls = mockExecCommand.mock.calls.filter(
       ([cmd, args]) =>
@@ -201,6 +257,12 @@ describe('ChannelsPage', () => {
         args[3] === 'wechat',
     )
     expect(loginCalls).toHaveLength(2)
+    expect(mockExecCommand).toHaveBeenCalledWith('openclaw', [
+      'channels',
+      'logout',
+      '--channel',
+      'wechat',
+    ])
   })
 
   it('opens recent logs from the contextual troubleshooting action', async () => {

--- a/packages/web/src/modules/channels/__tests__/ChannelsPage.test.tsx
+++ b/packages/web/src/modules/channels/__tests__/ChannelsPage.test.tsx
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { changeLanguage } from '@/i18n'
 import ChannelsPage from '../ChannelsPage'
@@ -38,6 +38,10 @@ function renderChannels() {
 }
 
 describe('ChannelsPage', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   beforeEach(async () => {
     vi.clearAllMocks()
     await changeLanguage('zh')
@@ -106,6 +110,97 @@ describe('ChannelsPage', () => {
       '-g',
       '@tencent-weixin/openclaw-weixin',
     ])
+  })
+
+  it('keeps cancel available during WeChat QR scanning and stops polling after close', async () => {
+    mockExecCommand.mockImplementation(async (cmd: string, args: string[]) => {
+      if (cmd === 'npm' && args[0] === 'list') {
+        return 'installed'
+      }
+      if (cmd === 'openclaw' && args[0] === 'channels' && args[1] === 'login') {
+        return 'login started'
+      }
+      if (cmd === 'openclaw' && args[0] === 'channels' && args[1] === 'status') {
+        return 'waiting'
+      }
+      return ''
+    })
+
+    renderChannels()
+
+    expect(await screen.findByText('推荐入口')).toBeInTheDocument()
+    fireEvent.click(screen.getAllByRole('button', { name: '开始配置' })[1])
+
+    await screen.findByText('已安装')
+    vi.useFakeTimers()
+    fireEvent.click(screen.getByRole('button', { name: '开始扫码登录' }))
+
+    await act(async () => {})
+
+    const cancelButton = screen.getByRole('button', { name: '取消' })
+    expect(cancelButton).not.toBeDisabled()
+
+    fireEvent.click(cancelButton)
+    expect(screen.queryByRole('dialog', { name: '微信' })).not.toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+
+    const statusCalls = mockExecCommand.mock.calls.filter(
+      ([cmd, args]) =>
+        cmd === 'openclaw' &&
+        Array.isArray(args) &&
+        args[0] === 'channels' &&
+        args[1] === 'status' &&
+        args[3] === 'wechat',
+    )
+    expect(statusCalls).toHaveLength(0)
+  })
+
+  it('shows timeout recovery and refreshes the WeChat QR login after expiry', async () => {
+    mockExecCommand.mockImplementation(async (cmd: string, args: string[]) => {
+      if (cmd === 'npm' && args[0] === 'list') {
+        return 'installed'
+      }
+      if (cmd === 'openclaw' && args[0] === 'channels' && args[1] === 'login') {
+        return 'login started'
+      }
+      if (cmd === 'openclaw' && args[0] === 'channels' && args[1] === 'status') {
+        return 'waiting'
+      }
+      return ''
+    })
+
+    renderChannels()
+
+    expect(await screen.findByText('推荐入口')).toBeInTheDocument()
+    fireEvent.click(screen.getAllByRole('button', { name: '开始配置' })[1])
+
+    await screen.findByText('已安装')
+    vi.useFakeTimers()
+    fireEvent.click(screen.getByRole('button', { name: '开始扫码登录' }))
+
+    await act(async () => {})
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60000)
+    })
+
+    expect(screen.getByText('登录超时，请重试')).toBeInTheDocument()
+    expect(screen.getByText('二维码可能已过期，请刷新后重新扫码。')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '刷新二维码' }))
+
+    const loginCalls = mockExecCommand.mock.calls.filter(
+      ([cmd, args]) =>
+        cmd === 'openclaw' &&
+        Array.isArray(args) &&
+        args[0] === 'channels' &&
+        args[1] === 'login' &&
+        args[3] === 'wechat',
+    )
+    expect(loginCalls).toHaveLength(2)
   })
 
   it('opens recent logs from the contextual troubleshooting action', async () => {


### PR DESCRIPTION
## What

- keep the WeChat QR login flow polling while the `openclaw channels login` command is still running
- keep `Cancel` enabled during QR scanning and clean up the active WeChat session with `openclaw channels logout --channel wechat`
- add an explicit timeout state with QR refresh recovery, and clean up the timed-out session before retry
- add focused Channels page tests for cancel, pending-login polling, and timeout recovery

Resolves #144.

## Why

The WeChat QR setup flow could get stuck in a non-cancelable waiting state and gave users no recovery path after a stale QR session. The UI also needed to stay responsive while the underlying login command was still active.

## How

- run the WeChat login command in the background while polling `openclaw channels status`
- invalidate stale attempts so late login failures cannot overwrite a newer `connected` or `timedOut` state
- call `openclaw channels logout --channel wechat` when canceling an active scan or refreshing after timeout
- extend the Channels tests to cover the new async state transitions

## Verification

- `npx vitest run src/modules/channels/__tests__/ChannelsPage.test.tsx`
- `npm run build`
- live `dev-browser` verification on `/channels`: after `开始扫码登录`, the modal stays in `等待扫码...`, `取消` remains enabled, and cancel closes the dialog immediately

## Screenshots

- Verified live with `dev-browser` on `/channels` in this CLI session; no GitHub-hosted screenshot asset was uploaded from the terminal session.
