### PR TITLE
Fix audit advisories and harden npm uninstall execution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@langchain/core": "^1.1.38",
+        "@langchain/core": "^1.1.45",
         "@sinclair/typebox": "^0.34.0",
         "@tauri-apps/api": "^2.10.1",
         "cors": "^2.8.5",
@@ -1078,9 +1078,9 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "1.1.39",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.39.tgz",
-      "integrity": "sha512-DP9c7TREy6iA7HnywstmUAsNyJNYTFpRg2yBfQ+6H0l1HnvQzei9GsQ36GeOLxgRaD3vm9K8urCcawSC7yQpCw==",
+      "version": "1.1.45",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.45.tgz",
+      "integrity": "sha512-Y/wvuglLTMKJahkl4QD9dBIdF/z/CxZJWdTfHJF/q2jtlJtoFf6Mb5JpGxZfsi3mBY6NSG941FSLTcqhCKrhBA==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
@@ -1092,7 +1092,6 @@
         "langsmith": ">=0.5.0 <1.0.0",
         "mustache": "^4.2.0",
         "p-queue": "^6.6.2",
-        "uuid": "^11.1.0",
         "zod": "^3.25.76 || ^4"
       },
       "engines": {
@@ -4163,13 +4162,12 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.18.tgz",
-      "integrity": "sha512-3zuZUWffTHQ+73EAwnodADtf534VNEZUpXr9jC12qyG8/IQuJET7PRsCpTb9wX2lmBspakwLUpqpj3tNm/0bVA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.6.3.tgz",
+      "integrity": "sha512-pXrQ4/4myQvjFFOAUmt5pWRrLEZR20gzIJD7MNdUH+5/S5nLI4ZRBo/SYKC6coaYj9pYTfQdBIzcs+3kfJ5uDA==",
       "license": "MIT",
       "dependencies": {
-        "p-queue": "6.6.2",
-        "uuid": "10.0.0"
+        "p-queue": "6.6.2"
       },
       "peerDependencies": {
         "@opentelemetry/api": "*",
@@ -4194,19 +4192,6 @@
         "ws": {
           "optional": true
         }
-      }
-    },
-    "node_modules/langsmith/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/lie": {
@@ -4886,9 +4871,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -6829,19 +6814,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -7734,7 +7706,7 @@
       "name": "@openclaw-manager/backend",
       "version": "0.3.1",
       "dependencies": {
-        "@langchain/core": "^1.1.38",
+        "@langchain/core": "^1.1.45",
         "cors": "^2.8.5",
         "express": "^4.21.0",
         "powermem": "^0.1.0",
@@ -7773,7 +7745,7 @@
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.20",
         "jsdom": "^29.0.1",
-        "postcss": "^8.4.49",
+        "postcss": "^8.5.14",
         "tailwindcss": "^3.4.17",
         "typescript": "~5.6.3",
         "vite": "^6.0.5",

--- a/package.json
+++ b/package.json
@@ -58,12 +58,15 @@
     "selenium-webdriver": "^4.34.0"
   },
   "dependencies": {
-    "@langchain/core": "^1.1.38",
+    "@langchain/core": "^1.1.45",
     "@sinclair/typebox": "^0.34.0",
     "@tauri-apps/api": "^2.10.1",
     "cors": "^2.8.5",
     "express": "^4.21.0",
     "powermem": "^0.1.0",
     "ws": "^8.18.0"
+  },
+  "overrides": {
+    "langsmith": "^0.6.3"
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@langchain/core": "^1.1.38",
+    "@langchain/core": "^1.1.45",
     "cors": "^2.8.5",
     "express": "^4.21.0",
     "powermem": "^0.1.0",

--- a/packages/backend/src/npmUninstallGlobalRobust.test.ts
+++ b/packages/backend/src/npmUninstallGlobalRobust.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import { npmUninstallGlobalRobust } from './npmUninstallGlobalRobust.js'
+
+function makeTempDir(label: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `clawmaster-${label}-`))
+}
+
+test('npmUninstallGlobalRobust rejects unsupported package names before invoking npm', async () => {
+  let called = false
+
+  const result = await npmUninstallGlobalRobust('openclaw; rm -rf /' as 'openclaw' | 'clawhub', {
+    execNpm: async () => {
+      called = true
+      return { code: 0, stdout: '', stderr: '' }
+    },
+  })
+
+  assert.equal(result.code, 1)
+  assert.equal(result.stderr, 'unsupported package')
+  assert.equal(called, false)
+})
+
+test('npmUninstallGlobalRobust uses argv-based npm execution for uninstall fallback flow', async () => {
+  const globalRoot = makeTempDir('npm-uninstall-root')
+  const packageDir = path.join(globalRoot, 'clawhub')
+  fs.mkdirSync(packageDir, { recursive: true })
+
+  const calls: string[][] = []
+  const result = await npmUninstallGlobalRobust('clawhub', {
+    execNpm: async (args) => {
+      calls.push(args)
+      if (calls.length === 1) {
+        return { code: 1, stdout: '', stderr: 'ENOTEMPTY rename failed' }
+      }
+      if (calls.length === 2) {
+        return { code: 1, stdout: '', stderr: 'still failing after force' }
+      }
+      if (calls.length === 3) {
+        return { code: 0, stdout: globalRoot, stderr: '' }
+      }
+      throw new Error(`Unexpected npm call: ${args.join(' ')}`)
+    },
+  })
+
+  assert.deepEqual(calls, [
+    ['uninstall', '-g', 'clawhub'],
+    ['uninstall', '-g', 'clawhub', '--force'],
+    ['root', '-g'],
+  ])
+  assert.equal(result.code, 0)
+  assert.match(result.stdout, /Removed global dir:/)
+  assert.equal(fs.existsSync(packageDir), false)
+})

--- a/packages/backend/src/npmUninstallGlobalRobust.ts
+++ b/packages/backend/src/npmUninstallGlobalRobust.ts
@@ -1,8 +1,14 @@
 import fs from 'fs'
 import path from 'path'
-import { execShellCommand } from './execOpenclaw.js'
+import { execNpmCommand } from './execOpenclaw.js'
 
 const ALLOWED = new Set(['openclaw', 'clawhub'])
+
+type NpmCommandRunner = (args: string[]) => Promise<{
+  code: number
+  stdout: string
+  stderr: string
+}>
 
 function looksLikeNpmRenameIssue(combined: string): boolean {
   return /ENOTEMPTY|rename|EPERM|EACCES|EEXIST/i.test(combined)
@@ -15,18 +21,20 @@ function looksLikeNpmRenameIssue(combined: string): boolean {
  * 3) else remove $(npm root -g)/<name> (only openclaw / clawhub allowed)
  */
 export async function npmUninstallGlobalRobust(
-  packageName: 'openclaw' | 'clawhub'
+  packageName: 'openclaw' | 'clawhub',
+  deps: { execNpm?: NpmCommandRunner } = {}
 ): Promise<{ code: number; stdout: string; stderr: string }> {
   if (!ALLOWED.has(packageName)) {
     return { code: 1, stdout: '', stderr: 'unsupported package' }
   }
+  const runNpm = deps.execNpm ?? execNpmCommand
 
-  let r = await execShellCommand(`npm uninstall -g ${packageName}`)
+  let r = await runNpm(['uninstall', '-g', packageName])
   if (r.code === 0) return r
 
   const combined = `${r.stderr}\n${r.stdout}`
   if (looksLikeNpmRenameIssue(combined)) {
-    const f = await execShellCommand(`npm uninstall -g ${packageName} --force`)
+    const f = await runNpm(['uninstall', '-g', packageName, '--force'])
     r = {
       code: f.code,
       stdout: [r.stdout, f.stdout].filter(Boolean).join('\n'),
@@ -35,7 +43,7 @@ export async function npmUninstallGlobalRobust(
     if (r.code === 0) return r
   }
 
-  const rootRes = await execShellCommand('npm root -g')
+  const rootRes = await runNpm(['root', '-g'])
   if (rootRes.code !== 0) {
     return {
       code: r.code,

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -32,7 +32,7 @@
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.20",
     "jsdom": "^29.0.1",
-    "postcss": "^8.4.49",
+    "postcss": "^8.5.14",
     "tailwindcss": "^3.4.17",
     "typescript": "~5.6.3",
     "vite": "^6.0.5",

--- a/packages/web/src/shared/adapters/__tests__/webHttp.test.ts
+++ b/packages/web/src/shared/adapters/__tests__/webHttp.test.ts
@@ -48,4 +48,24 @@ describe('webHttp auth helpers', () => {
     expect(headers.get('X-Clawmaster-Danger-Token')).toBe('secret-token')
     expect(headers.get('Content-Type')).toBe('application/json')
   })
+
+  it('uses wss for websocket URLs on https origins', async () => {
+    vi.stubGlobal('window', {
+      location: { href: 'https://clawmaster.test/app' },
+    })
+
+    const { createAuthedWebSocketUrl } = await import('../webHttp')
+
+    expect(createAuthedWebSocketUrl('/api/logs/stream')).toBe('wss://clawmaster.test/api/logs/stream')
+  })
+
+  it('uses ws for websocket URLs on http origins', async () => {
+    vi.stubGlobal('window', {
+      location: { href: 'http://clawmaster.test/app' },
+    })
+
+    const { createAuthedWebSocketUrl } = await import('../webHttp')
+
+    expect(createAuthedWebSocketUrl('/api/logs/stream')).toBe('ws://clawmaster.test/api/logs/stream')
+  })
 })

--- a/plugins/memory-clawmaster-powermem/package.json
+++ b/plugins/memory-clawmaster-powermem/package.json
@@ -14,7 +14,7 @@
     "openclaw.plugin.json"
   ],
   "dependencies": {
-    "@langchain/core": "^1.1.38",
+    "@langchain/core": "^1.1.45",
     "@sinclair/typebox": "^0.34.0",
     "powermem": "^0.1.0"
   },


### PR DESCRIPTION
## What
- remediate the current npm audit advisories by updating the resolved `postcss` and `@langchain/core` dependency paths and overriding `langsmith` to a non-vulnerable version
- harden the global uninstall flow to use argv-based npm execution instead of string shell commands
- add regression tests for secure uninstall invocation and `ws`/`wss` websocket URL generation
- comment on PR #148 to separate the badge PR from the actual security remediation work

Closes #149.

## Why
PR #148 surfaced real dependency advisories, but the code change in that PR only adds a README badge. The actual remediation needed to happen in a separate change that clears audit findings and removes the most obvious command-execution scanner signal.

## How
- bumped `@langchain/core` to `^1.1.45` in root, backend, and the managed memory plugin
- bumped `postcss` to `^8.5.14` in the web workspace
- added a root `overrides` entry for `langsmith` so CI resolves a fixed transitive version consistently
- switched `npmUninstallGlobalRobust()` to call `execNpmCommand()` with argument arrays for `npm uninstall -g` and `npm root -g`
- added a backend unit test to verify the uninstall path rejects unsupported package names and uses argv-based execution
- added web tests proving websocket URLs resolve to `wss://` under `https:` and `ws://` under `http:`

## Verification
- `npm audit --json`
- `npm audit --workspace=@openclaw-manager/backend --json`
- `npm audit --workspace=@openclaw-manager/web --json`
- `npm run build`
- `npm test`

## Screenshots
- No UI changes.
